### PR TITLE
Add Toolchain Installer and Cocotb Test Suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Cocotb / Simulation
+sim_build/
+results.xml
+*.vvp
+*.vcd
+
+# FPGA / Gowin Build Artifacts
+*.json
+*.fs
+*.map
+
+# Firmware Build Artifacts
+*.o
+*.elf
+*.bin
+
+# OS
+.DS_Store

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,10 @@
 - [ ] Define VGA to HDMI conversion logic.
 - [ ] Implement VGA input interface for Tiny Tapeout designs.
 - [ ] Integrate HDMI output for Tang Nano 4K.
-- [ ] Create example Tiny Tapeout projects for testing.
+- [ ] Add example Tiny Tapeout VGA designs.
 
 ## Completed
 - [x] Initial exploration and base project selection.
 - [x] Project Initialization: Set up repository structure and foundational UART project.
 - [x] Technical debt cleanup and UART pin synchronization.
+- [x] Toolchain installer (`install.sh`) and Cocotb test suite integration (`run_tests.sh`).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+echo "Installing Toolchain for VGA-to-HDMI Project..."
+
+# Update package list
+sudo apt-get update
+
+# Install FPGA Tools
+echo "Installing FPGA Tools (Yosys, Nextpnr-Gowin, Iverilog)..."
+sudo apt-get install -y yosys nextpnr-gowin iverilog
+
+# Install ARM Cross-Compiler
+echo "Installing ARM Cross-Compiler..."
+sudo apt-get install -y gcc-arm-none-eabi binutils-arm-none-eabi libnewlib-arm-none-eabi
+
+# Install Python Tools (Cocotb, Apycula)
+echo "Installing Python Tools (Cocotb, Apycula)..."
+pip3 install --upgrade pip
+pip3 install cocotb cocotb-test apycula
+
+echo "Toolchain installation complete!"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+echo "Running all tests..."
+
+# 1. Structural Tests
+echo "--- Running Structural Verification ---"
+bash test/test_structure.sh
+
+# 2. Cocotb Tests
+echo "--- Running Cocotb Simulation Tests ---"
+cd test
+make -f cocotb_Makefile
+cd ..
+
+echo "All tests passed successfully!"

--- a/test/cocotb_Makefile
+++ b/test/cocotb_Makefile
@@ -1,0 +1,9 @@
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+VERILOG_SOURCES += $(PWD)/../src/tt_project.v
+
+TOPLEVEL = tt_um_minimal_echo
+COCOTB_TEST_MODULES = test_tt_project
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/test_tt_project.py
+++ b/test/test_tt_project.py
@@ -1,0 +1,34 @@
+import cocotb
+from cocotb.triggers import Timer, RisingEdge
+
+@cocotb.test()
+async def test_tt_um_minimal_echo(dut):
+    """Test the minimal echo module"""
+
+    dut._log.info("Starting test_tt_um_minimal_echo")
+
+    # Initial values
+    dut.ui_in.value = 0
+    dut.uio_in.value = 0
+    dut.ena.value = 1
+    dut.clk.value = 0
+    dut.rst_n.value = 0
+
+    # Wait for a bit
+    await Timer(10, unit="ns")
+    dut.rst_n.value = 1
+    await Timer(10, unit="ns")
+
+    # Test echoing ui_in to uo_out
+    for i in range(256):
+        dut.ui_in.value = i
+        await Timer(1, unit="ns")
+        assert dut.uo_out.value == i, f"Expected {i}, got {dut.uo_out.value}"
+
+    # Test UIO outputs
+    # assign uio_out = 8'b10101100;
+    # assign uio_oe  = 8'b11111111;
+    assert dut.uio_out.value == 0b10101100, f"Expected 0b10101100, got {dut.uio_out.value}"
+    assert dut.uio_oe.value == 0b11111111, f"Expected 0b11111111, got {dut.uio_oe.value}"
+
+    dut._log.info("Test passed!")


### PR DESCRIPTION
This change introduces automation for environment setup and testing.
The `install.sh` script installs all necessary dependencies for FPGA synthesis, firmware compilation, and simulation.
The `run_tests.sh` script provides a unified entry point for all project tests, currently including structural verification and a Cocotb-based simulation of the Tiny Tapeout echo module.
A `.gitignore` file has been added to keep the repository clean of build artifacts.

Fixes #5

---
*PR created automatically by Jules for task [12718350680899708511](https://jules.google.com/task/12718350680899708511) started by @chatelao*