### PR TITLE
Compile smallest VGA project in CI/CD

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,9 @@
 # ROADMAP
 
 ## Current Goals
+- [x] Integrate `tt_um_vga_example` into the top-level design.
+- [x] Develop automated synthesis tests for the VGA project in CI.
 - [ ] Implement VGA to HDMI conversion logic in Verilog.
-- [ ] Integrate `tt_um_minimal_echo` or other TT projects into the top-level design.
 - [ ] Configure Renode to simulate the Tang Nano 4K (GW1NSR-LV4C) and verify binaries.
 - [ ] Expand the APB expansion logic to support full 8-bit TT address space.
 - [ ] Develop automated E2E tests for video signal integrity.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,4 +14,12 @@ cd test
 make -f cocotb_Makefile
 cd ..
 
+# 3. Synthesis Tests
+echo "--- Running Synthesis Test ---"
+yosys -p "synth_gowin -top tt_um_vga_example -json tt_vga.json" src/tt_project.v src/hvsync_generator.v
+nextpnr-gowin --device GW1NSR-LV4CQN48PC7/I6 --family GW1NS-4 --json tt_vga.json --write tt_vga_pnr.json
+# Note: gowin_pack from apycula requires nextpnr-himbaechel which is not available in standard apt packages yet.
+# We skip bitstream generation for now but keep synthesis and P&R check.
+rm tt_vga.json tt_vga_pnr.json
+
 echo "All tests passed successfully!"

--- a/src/hvsync_generator.v
+++ b/src/hvsync_generator.v
@@ -1,0 +1,69 @@
+`ifndef HVSYNC_GENERATOR_H
+`define HVSYNC_GENERATOR_H
+
+/*
+Video sync generator, used to drive a VGA monitor.
+Timing from: https://en.wikipedia.org/wiki/Video_Graphics_Array
+To use:
+- Wire the hsync and vsync signals to top level outputs
+- Add a 3-bit (or more) "rgb" output to the top level
+*/
+
+module hvsync_generator(clk, reset, hsync, vsync, display_on, hpos, vpos);
+
+  input clk;
+  input reset;
+  output reg hsync, vsync;
+  output display_on;
+  output reg [9:0] hpos;
+  output reg [9:0] vpos;
+
+  // declarations for TV-simulator sync parameters
+  // horizontal constants
+  parameter H_DISPLAY       = 640; // horizontal display width
+  parameter H_BACK          =  48; // horizontal left border (back porch)
+  parameter H_FRONT         =  16; // horizontal right border (front porch)
+  parameter H_SYNC          =  96; // horizontal sync width
+  // vertical constants
+  parameter V_DISPLAY       = 480; // vertical display height
+  parameter V_TOP           =  33; // vertical top border
+  parameter V_BOTTOM        =  10; // vertical bottom border
+  parameter V_SYNC          =   2; // vertical sync # lines
+  // derived constants
+  parameter H_SYNC_START    = H_DISPLAY + H_FRONT;
+  parameter H_SYNC_END      = H_DISPLAY + H_FRONT + H_SYNC - 1;
+  parameter H_MAX           = H_DISPLAY + H_BACK + H_FRONT + H_SYNC - 1;
+  parameter V_SYNC_START    = V_DISPLAY + V_BOTTOM;
+  parameter V_SYNC_END      = V_DISPLAY + V_BOTTOM + V_SYNC - 1;
+  parameter V_MAX           = V_DISPLAY + V_TOP + V_BOTTOM + V_SYNC - 1;
+
+  wire hmaxxed = (hpos == H_MAX) || reset;	// set when hpos is maximum
+  wire vmaxxed = (vpos == V_MAX) || reset;	// set when vpos is maximum
+
+  // horizontal position counter
+  always @(posedge clk)
+  begin
+    hsync <= ~(hpos>=H_SYNC_START && hpos<=H_SYNC_END);
+    if(hmaxxed)
+      hpos <= 0;
+    else
+      hpos <= hpos + 1;
+  end
+
+  // vertical position counter
+  always @(posedge clk)
+  begin
+    vsync <= ~(vpos>=V_SYNC_START && vpos<=V_SYNC_END);
+    if(hmaxxed)
+      if (vmaxxed)
+        vpos <= 0;
+      else
+        vpos <= vpos + 1;
+  end
+
+  // display_on is set when beam is in "safe" visible frame
+  assign display_on = (hpos<H_DISPLAY) && (vpos<V_DISPLAY);
+
+endmodule
+
+`endif

--- a/src/tt_project.v
+++ b/src/tt_project.v
@@ -1,27 +1,68 @@
 /*
- * Minimal Tiny Tapeout Echo Project
- *
- * This design simply echoes the input byte (ui_in) to the output byte (uo_out).
+ * Copyright (c) 2024 Uri Shaked
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 `default_nettype none
 
-module tt_um_minimal_echo (
-    input  wire [7:0] ui_in,    // Dedicated inputs
-    output wire [7:0] uo_out,   // Dedicated outputs
-    input  wire [7:0] uio_in,   // IOs: Input path
-    output wire [7:0] uio_out,  // IOs: Output path
-    output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
-    input  wire       ena,      // always 1 when the design is powered, so you can ignore it
-    input  wire       clk,      // clock
-    input  wire       rst_n     // reset_n - low to reset
+module tt_um_vga_example(
+  input  wire [7:0] ui_in,    // Dedicated inputs
+  output wire [7:0] uo_out,   // Dedicated outputs
+  input  wire [7:0] uio_in,   // IOs: Input path
+  output wire [7:0] uio_out,  // IOs: Output path
+  output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+  input  wire       ena,      // always 1 when the design is powered, so you can ignore it
+  input  wire       clk,      // clock
+  input  wire       rst_n     // reset_n - low to reset
 );
 
-    // Assign inputs directly to outputs
-    assign uo_out  = ui_in;
+  // VGA signals
+  wire hsync;
+  wire vsync;
+  wire [1:0] R;
+  wire [1:0] G;
+  wire [1:0] B;
+  wire video_active;
+  wire [9:0] pix_x;
+  wire [9:0] pix_y;
 
-    // Set UIO to output and show b'10101100
-    assign uio_out = 8'b10101100;
-    assign uio_oe  = 8'b11111111;
+  // TinyVGA PMOD
+  assign uo_out = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
+
+  // Unused outputs assigned to 0.
+  assign uio_out = 0;
+  assign uio_oe  = 0;
+
+  // Suppress unused signals warning
+  wire _unused_ok = &{ena, ui_in, uio_in};
+
+  reg [9:0] counter;
+
+  hvsync_generator hvsync_gen(
+    .clk(clk),
+    .reset(~rst_n),
+    .hsync(hsync),
+    .vsync(vsync),
+    .display_on(video_active),
+    .hpos(pix_x),
+    .vpos(pix_y)
+  );
+
+  wire [9:0] moving_x = pix_x + counter;
+
+  assign R = video_active ? {moving_x[5], pix_y[2]} : 2'b00;
+  assign G = video_active ? {moving_x[6], pix_y[2]} : 2'b00;
+  assign B = video_active ? {moving_x[7], pix_y[5]} : 2'b00;
+
+  always @(posedge vsync, negedge rst_n) begin
+    if (~rst_n) begin
+      counter <= 0;
+    end else begin
+      counter <= counter + 1;
+    end
+  end
+
+  // Suppress unused signals warning
+  wire _unused_ok_ = &{moving_x, pix_y};
 
 endmodule

--- a/src/tt_wrapper.v
+++ b/src/tt_wrapper.v
@@ -83,8 +83,8 @@ module tt_m3_wrapper (
     end
 
     // --- Tiny Tapeout Module Instantiation ---
-    // Note: Change 'tt_um_minimal_echo' to your actual TT module name
-    tt_um_minimal_echo tt_inst (
+    // Note: Change 'tt_um_vga_example' to your actual TT module name
+    tt_um_vga_example tt_inst (
         .ui_in  (ui_in),
         .uo_out (uo_out),
         .uio_in (uio_in),

--- a/test/cocotb_Makefile
+++ b/test/cocotb_Makefile
@@ -2,8 +2,9 @@ SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 
 VERILOG_SOURCES += $(PWD)/../src/tt_project.v
+VERILOG_SOURCES += $(PWD)/../src/hvsync_generator.v
 
-TOPLEVEL = tt_um_minimal_echo
+TOPLEVEL = tt_um_vga_example
 COCOTB_TEST_MODULES = test_tt_project
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/test_tt_project.py
+++ b/test/test_tt_project.py
@@ -1,11 +1,11 @@
 import cocotb
-from cocotb.triggers import Timer, RisingEdge
+from cocotb.triggers import Timer, RisingEdge, ClockCycles
 
 @cocotb.test()
-async def test_tt_um_minimal_echo(dut):
-    """Test the minimal echo module"""
+async def test_tt_um_vga_example(dut):
+    """Test the VGA example module"""
 
-    dut._log.info("Starting test_tt_um_minimal_echo")
+    dut._log.info("Starting test_tt_um_vga_example")
 
     # Initial values
     dut.ui_in.value = 0
@@ -14,21 +14,42 @@ async def test_tt_um_minimal_echo(dut):
     dut.clk.value = 0
     dut.rst_n.value = 0
 
-    # Wait for a bit
-    await Timer(10, unit="ns")
+    # Pulse clock while reset is active to initialize registers
+    for _ in range(10):
+        await Timer(5, unit="ns")
+        dut.clk.value = 1
+        await Timer(5, unit="ns")
+        dut.clk.value = 0
+
+    # Release reset
     dut.rst_n.value = 1
     await Timer(10, unit="ns")
 
-    # Test echoing ui_in to uo_out
-    for i in range(256):
-        dut.ui_in.value = i
-        await Timer(1, unit="ns")
-        assert dut.uo_out.value == i, f"Expected {i}, got {dut.uo_out.value}"
+    # Run for some cycles and check for activity on hsync (uo_out[7])
+    # HSYNC is active low in hvsync_generator.v
 
-    # Test UIO outputs
-    # assign uio_out = 8'b10101100;
-    # assign uio_oe  = 8'b11111111;
-    assert dut.uio_out.value == 0b10101100, f"Expected 0b10101100, got {dut.uio_out.value}"
-    assert dut.uio_oe.value == 0b11111111, f"Expected 0b11111111, got {dut.uio_oe.value}"
+    hsync_found_low = False
+    hsync_found_high = False
+
+    for i in range(2000):
+        dut.clk.value = 1
+        await Timer(5, unit="ns")
+        dut.clk.value = 0
+        await Timer(5, unit="ns")
+
+        try:
+            uo_out = int(dut.uo_out.value)
+            hsync = (uo_out >> 7) & 1
+
+            if hsync == 0:
+                hsync_found_low = True
+            if hsync == 1:
+                hsync_found_high = True
+        except ValueError:
+            if i % 100 == 0:
+                dut._log.info(f"Cycle {i}: uo_out is still {dut.uo_out.value}")
+
+    assert hsync_found_high, "hsync never went high"
+    assert hsync_found_low, "hsync never went low"
 
     dut._log.info("Test passed!")


### PR DESCRIPTION
This change replaces the minimal echo Tiny Tapeout project with a VGA pattern generator (the smallest VGA project from the examples). It also updates the CI process (run_tests.sh) to include full FPGA synthesis and Place & Route verification using Yosys and nextpnr-gowin, ensuring that the design is physically realizable on the Tang Nano 4K. Verification is performed via Cocotb simulation (checking sync signals) and structural checks.

Fixes #13

---
*PR created automatically by Jules for task [8619648105289283892](https://jules.google.com/task/8619648105289283892) started by @chatelao*