### PR TITLE
Integrate smallest TT VGA project compilation into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,3 @@ jobs:
 
       - name: Run Tests
         run: bash run_tests.sh
-
-      - name: Compile Smallest TT VGA Project
-        run: bash compile_minimal.sh

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,11 @@
 # ROADMAP
 
 ## Current Goals
-- [x] Integrate `tt_um_vga_example` into the top-level design.
-- [x] Develop automated synthesis tests for the VGA project in CI.
-- [x] Compile smallest TT VGA project in CI.
 - [ ] Implement VGA to HDMI conversion logic in Verilog.
 - [ ] Configure Renode to simulate the Tang Nano 4K (GW1NSR-LV4C) and verify binaries.
 - [ ] Expand the APB expansion logic to support full 8-bit TT address space.
 - [ ] Develop automated E2E tests for video signal integrity.
+- [ ] Integrate HDMI output with the top-level design.
 
 ## Completed
 - [x] Initial exploration and base project selection.
@@ -17,3 +15,6 @@
 - [x] Implement GitHub Actions for automated testing.
 - [x] Update project structure and documentation according to GEMINI.md.
 - [x] Add VGA Playground examples to `examples/tt_projects`.
+- [x] Integrate `tt_um_vga_example` into the top-level design.
+- [x] Develop automated synthesis tests for the VGA project in CI.
+- [x] Compile smallest TT VGA project in CI.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,11 +15,12 @@ make -f cocotb_Makefile
 cd ..
 
 # 3. Synthesis Tests
-echo "--- Running Synthesis Test ---"
+echo "--- Running Synthesis Test (Main Project) ---"
 yosys -p "synth_gowin -top tt_um_vga_example -json tt_vga.json" src/tt_project.v src/hvsync_generator.v
 nextpnr-gowin --device GW1NSR-LV4CQN48PC7/I6 --family GW1NS-4 --json tt_vga.json --write tt_vga_pnr.json
-# Note: gowin_pack from apycula requires nextpnr-himbaechel which is not available in standard apt packages yet.
-# We skip bitstream generation for now but keep synthesis and P&R check.
 rm tt_vga.json tt_vga_pnr.json
+
+echo "--- Running Synthesis Test (Minimal VGA Project) ---"
+bash compile_minimal.sh
 
 echo "All tests passed successfully!"


### PR DESCRIPTION
This change integrates the compilation of the smallest Tiny Tapeout VGA project (`tt_um_minimal_vga`) into the automated test suite. Previously, it was a standalone step in the GitHub Actions workflow, but now it's part of `run_tests.sh`, ensuring consistent verification both locally and in CI. The change also includes updates to `ROADMAP.md` to track progress.

Fixes #18

---
*PR created automatically by Jules for task [9232313401157141540](https://jules.google.com/task/9232313401157141540) started by @chatelao*