### PR TITLE
Refine Roadmap and Document TT APB Register Map

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -5,8 +5,10 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 ## VGA to HDMI Integration
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.
 - [x] Assign physical pins for HDMI TMDS pairs in `src/top.cst`.
-- [ ] Implement the TMDS clocking logic (PLL for 5x/10x serialization clock).
-- [ ] Implement the OSER10-based serializer for Gowin GW1NSR-4C.
+- [ ] Implement a PLL module for HDMI clock generation (Pixel/Serial clocks).
+- [ ] Verify PLL clock outputs and lock signal in simulation.
+- [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
+- [ ] Map serializer outputs to differential pairs in the top-level design.
 - [ ] Integrate components into a top-level `hdmi_tx` module.
 - [ ] Connect `tt_um_vga_example` signals to the `hdmi_tx` core.
 - [ ] Verify HDMI output timing and encoding via Cocotb simulation.
@@ -20,9 +22,9 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## APB Expansion & Bridge
 - [x] Expand `tt_wrapper.v` to support full 8-bit address decoding (preventing aliasing).
+- [x] Document the TT APB register map in `README.md`.
 - [ ] Update `m3_regs.h` with additional TT control/status registers if needed.
 - [ ] Implement firmware-based read-back verification for all TT registers.
-- [ ] Document the TT APB register map in `README.md`.
 
 ## Automated E2E & Verification
 - [ ] Develop a Cocotb test bench for the complete `top` module.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This project provides a hardware bridge to display Tiny Tapeout (TT) VGA designs
 - `/test`: Test suite including Cocotb and Renode configurations.
 - `ROADMAP.md`: Tracking progress and future milestones.
 
+## Tiny Tapeout APB Register Map
+The Cortex-M3 interacts with the Tiny Tapeout module via an APB bridge located at base address `0x40002400`.
+
+| Offset | Name     | Access | Description |
+|--------|----------|--------|-------------|
+| 0x00   | DATA     | R/W    | Write: `ui_in`, Read: `uo_out` |
+| 0x04   | UIO_DATA | R/W    | Write: `uio_in`, Read: `uio_out` |
+| 0x08   | UIO_OE   | R      | Read: `uio_oe` |
+| 0x0C   | CTRL     | R/W    | [0]=clk, [1]=rst_n (Active Low), [2]=ena |
+
 ## Getting Started
 Run `bash install.sh` to set up the toolchain.
 Run `bash run_tests.sh` to execute the verification suite.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,10 @@
 
 ## Current Goals
 - [ ] Implement a custom Renode peripheral model for the TT APB bridge.
-- [ ] Develop automated E2E tests for video signal integrity.
-- [ ] Implement the TMDS clocking logic (PLL for 5x/10x serialization clock).
-- [ ] Implement the OSER10-based serializer for Gowin GW1NSR-4C.
+- [ ] Implement a PLL module for HDMI clock generation (Pixel/Serial clocks).
+- [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [ ] Integrate components into a top-level `hdmi_tx` module.
+- [ ] Develop automated E2E tests for video signal integrity.
 
 ## Completed
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.


### PR DESCRIPTION
I have completed the task of refining the project's roadmap and implementing a modest documentation step.

Specifically:
1.  **Documented the Tiny Tapeout (TT) APB Register Map in `README.md`**: I added a detailed table describing the registers at base address `0x40002400` (DATA, UIO_DATA, UIO_OE, CTRL), which allows the Cortex-M3 to interact with the TT module.
2.  **Refined `ROADMAP.md`**: I broke down the high-level goals for HDMI clocking and serialization into smaller, more manageable steps (PLL implementation and OSER10-based serializer implementation). I ensured that the "Current Goals" section maintains exactly 5 uncompleted tasks, as per project constraints.
3.  **Updated `MIGRATION_ROADMAP.md`**: I marked the documentation task as completed and synchronized the HDMI integration sub-tasks with the refined goals in the main roadmap.

These changes improve the project's clarity and provide a more granular path for future development. I verified the changes by running the structural and synthesis tests in `./run_tests.sh`.

Fixes #29

---
*PR created automatically by Jules for task [10733571763528314771](https://jules.google.com/task/10733571763528314771) started by @chatelao*