### PR TITLE
HDMI Clock Generation Infrastructure

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -5,9 +5,9 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 ## VGA to HDMI Integration
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.
 - [x] Assign physical pins for HDMI TMDS pairs in `src/top.cst`.
-- [ ] Create behavioral PLL model for simulation.
-- [ ] Implement Gowin `rPLL` hardware module for HDMI clock generation (Pixel/Serial clocks).
-- [ ] Verify PLL clock outputs and lock signal in simulation.
+- [x] Create behavioral PLL model for simulation.
+- [x] Implement Gowin `rPLL` hardware module for HDMI clock generation (Pixel/Serial clocks).
+- [x] Verify PLL clock outputs and lock signal in simulation.
 - [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [ ] Map serializer outputs to differential pairs in the top-level design.
 - [ ] Integrate components into a top-level `hdmi_tx` module.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,8 @@
 ## Current Goals
 - [ ] Define a basic Renode peripheral model for the TT APB bridge.
 - [ ] Verify APB bridge in Renode with UART echo firmware.
-- [ ] Create behavioral PLL model for simulation.
-- [ ] Implement Gowin `rPLL` hardware module.
+- [x] Create behavioral PLL model for simulation.
+- [x] Implement Gowin `rPLL` hardware module.
 - [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 
 ## Completed

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -13,7 +13,10 @@ echo "--- Running Cocotb Simulation Tests ---"
 cd test
 export IVERILOG=iverilog
 export VVP=vvp
+make -f cocotb_Makefile clean
 make -f cocotb_Makefile
+make -f Makefile.pll clean
+make -f Makefile.pll
 cd ..
 
 # 3. Synthesis Tests

--- a/src/hdmi_clk_gen.v
+++ b/src/hdmi_clk_gen.v
@@ -1,0 +1,57 @@
+/*
+ * HDMI Clock Generator for Tang Nano 4K (GW1NSR-LV4C)
+ *
+ * Generates:
+ *  - Serial Clock (x10): 252 MHz
+ *  - Pixel Clock (x1): 25.2 MHz
+ * From:
+ *  - Input Clock: 27 MHz
+ *
+ * Parameters for 640x480 @ 60Hz:
+ *  - FCLKIN: 27 MHz
+ *  - IDIV_SEL: 2 (IDIV = 3)
+ *  - FBDIV_SEL: 27 (FBDIV = 28)
+ *  - ODIV_SEL: 4 (ODIV = 4) -- Note: ODIV is often required for VCO stability
+ *  - CLKOUTD_SEL: 10 (Divider for CLKOUTD)
+ */
+
+`default_nettype none
+
+module hdmi_clk_gen (
+    input  wire clk_in,    // 27 MHz
+    input  wire reset,     // Active high reset
+    output wire clk_pixel, // 25.2 MHz
+    output wire clk_x10,   // 252 MHz
+    output wire lock       // PLL lock signal
+);
+
+    wire clkout_internal;
+
+    rPLL #(
+        .FCLKIN("27"),
+        .DEVICE("GW1NSR-4C"),
+        .IDIV_SEL(2),       // IDIV = 3
+        .FBDIV_SEL(55),      // FBDIV = 56
+        .ODIV_SEL(2),        // ODIV = 2
+        .PSDA_SEL("0000"),
+        .DUTYDA_SEL("1000"),
+        .CLKOUTD_SRC("CLKOUT"),
+        .CLKOUTD_SEL(10)     // SDIV = 10
+    ) pll_inst (
+        .CLKIN(clk_in),
+        .CLKOUT(clkout_internal),
+        .CLKOUTD(clk_pixel),
+        .LOCK(lock),
+        .RESET(reset),
+        .RESET_P(1'b0),
+        .CLKFB(1'b0),
+        .FBDSEL(6'b0),
+        .IDSEL(6'b0),
+        .ODSEL(6'b0),
+        .DUTYDA(4'b0),
+        .FDLY(4'b0)
+    );
+
+    assign clk_x10 = clkout_internal;
+
+endmodule

--- a/test/Makefile.pll
+++ b/test/Makefile.pll
@@ -1,0 +1,10 @@
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+VERILOG_SOURCES += $(PWD)/../src/hdmi_clk_gen.v
+VERILOG_SOURCES += $(PWD)/rpll_sim_model.v
+
+TOPLEVEL = hdmi_clk_gen
+COCOTB_TEST_MODULES = test_hdmi_clk_gen
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/rpll_sim_model.v
+++ b/test/rpll_sim_model.v
@@ -1,0 +1,101 @@
+/*
+ * Behavioral model of Gowin rPLL for simulation with Icarus Verilog.
+ *
+ * This model approximates the frequency scaling of the rPLL primitive.
+ * It is NOT a cycle-accurate representation of the hardware's analog behavior.
+ */
+
+`timescale 1ns/1ps
+
+module rPLL #(
+    parameter FCLKIN = "27",
+    parameter DEVICE = "GW1NSR-4C",
+    parameter IDIV_SEL = 0,
+    parameter FBDIV_SEL = 0,
+    parameter ODIV_SEL = 8,
+    parameter DUTYDA_SEL = "1000",
+    parameter PSDA_SEL = "0000",
+    parameter CLKOUTD_SRC = "CLKOUT",
+    parameter CLKOUTD_SEL = 2
+)(
+    input  wire CLKIN,
+    input  wire RESET,
+    input  wire RESET_P,
+    input  wire CLKFB,
+    input  wire [5:0] FBDSEL,
+    input  wire [5:0] IDSEL,
+    input  wire [5:0] ODSEL,
+    input  wire [3:0] DUTYDA,
+    input  wire [3:0] FDLY,
+    output reg  CLKOUT,
+    output reg  CLKOUTD,
+    output reg  LOCK
+);
+
+    // Factors based on Gowin documentation (approximate)
+    // IDIV = IDIV_SEL + 1
+    // FBDIV = FBDIV_SEL + 1
+    // ODIV = ODIV_SEL (Wait, usually ODIV is one of 2, 4, 8, 16...)
+    // For our specific case:
+    // IDIV = 3 (IDIV_SEL=2)
+    // FBDIV = 28 (FBDIV_SEL=27)
+    // Target Frequency = (27 * 28) / 3 = 252 MHz
+    // Pixel Clock = 252 / 10 = 25.2 MHz (CLKOUTD_SEL=10)
+
+    real input_period = 0;
+    real last_edge = 0;
+    real vco_period = 0;
+
+    initial begin
+        CLKOUT = 0;
+        CLKOUTD = 0;
+        LOCK = 0;
+    end
+
+    // Measure input period
+    always @(posedge CLKIN) begin
+        if (last_edge != 0) begin
+            input_period = $realtime - last_edge;
+            // Target output period: input_period * IDIV * ODIV / FBDIV
+            // For 252 MHz: 37.037 * 3 * 2 / 56 = 3.968 ns
+            vco_period = (input_period * (IDIV_SEL + 1.0) * ODIV_SEL) / (FBDIV_SEL + 1.0);
+        end
+        last_edge = $realtime;
+    end
+
+    // Generate LOCK signal
+    always @(posedge CLKIN or posedge RESET) begin
+        if (RESET) begin
+            LOCK <= 0;
+        end else begin
+            // Simple delay to simulate locking
+            #100 LOCK <= 1;
+        end
+    end
+
+    // Generate CLKOUT (x10)
+    always begin
+        if (LOCK && vco_period > 0) begin
+            #(vco_period / 2.0) CLKOUT = ~CLKOUT;
+        end else begin
+            #1 CLKOUT = 0;
+        end
+    end
+
+    // Generate CLKOUTD (x1)
+    integer d_count = 0;
+    always @(posedge CLKOUT) begin
+        if (!LOCK) begin
+            d_count <= 0;
+            CLKOUTD <= 0;
+        end else begin
+            if (d_count >= (CLKOUTD_SEL / 2) - 1) begin
+                CLKOUTD <= ~CLKOUTD;
+                d_count <= 0;
+            end else begin
+                d_count <= d_count + 1;
+            end
+        end
+    end
+
+endmodule

--- a/test/test_hdmi_clk_gen.py
+++ b/test/test_hdmi_clk_gen.py
@@ -1,0 +1,50 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+import logging
+
+@cocotb.test()
+async def test_hdmi_clk_gen(dut):
+    """Test HDMI clock generation frequencies"""
+
+    # 27 MHz input clock (Period approx 37.037 ns)
+    # Using 37038 ps to be divisible by 2
+    cocotb.start_soon(Clock(dut.clk_in, 37038, unit="ps").start())
+
+    # Reset
+    dut.reset.value = 1
+    await Timer(100, unit="ns")
+    dut.reset.value = 0
+
+    # Wait for LOCK
+    await RisingEdge(dut.lock)
+    dut._log.info("PLL Locked")
+
+    # Measure clk_x10 (Serial Clock)
+    # Expected: 252 MHz (Period = 3.968 ns)
+    await RisingEdge(dut.clk_x10)
+    t1 = cocotb.utils.get_sim_time(unit="ns")
+    await RisingEdge(dut.clk_x10)
+    t2 = cocotb.utils.get_sim_time(unit="ns")
+    period_x10 = t2 - t1
+    freq_x10 = 1000 / period_x10
+
+    dut._log.info(f"clk_x10 Period: {period_x10:.3f} ns ({freq_x10:.2f} MHz)")
+    assert 3.9 < period_x10 < 4.1, f"clk_x10 period {period_x10} out of range"
+
+    # Measure clk_pixel (Pixel Clock)
+    # Expected: 25.2 MHz (Period = 39.68 ns)
+    await RisingEdge(dut.clk_pixel)
+    t1 = cocotb.utils.get_sim_time(unit="ns")
+    await RisingEdge(dut.clk_pixel)
+    t2 = cocotb.utils.get_sim_time(unit="ns")
+    period_pixel = t2 - t1
+    freq_pixel = 1000 / period_pixel
+
+    dut._log.info(f"clk_pixel Period: {period_pixel:.3f} ns ({freq_pixel:.2f} MHz)")
+    assert 39.0 < period_pixel < 40.5, f"clk_pixel period {period_pixel} out of range"
+
+    # Verify 10:1 ratio
+    ratio = period_pixel / period_x10
+    dut._log.info(f"Clock Ratio: {ratio:.2f}")
+    assert 9.9 < ratio < 10.1, f"Clock ratio {ratio} is not approx 10"


### PR DESCRIPTION
This change implements the HDMI clock generation infrastructure for the Tang Nano 4K. It includes:
1. **Hardware Implementation**: A new Verilog module `src/hdmi_clk_gen.v` that uses the Gowin `rPLL` primitive. It is configured to produce a 25.2 MHz pixel clock and a 252 MHz serial clock (x10) from the 27 MHz onboard oscillator. The VCO is set to 504 MHz (stable range) with an ODIV of 2.
2. **Behavioral Simulation Model**: `test/rpll_sim_model.v` allows the vendor-specific `rPLL` to be simulated in open-source tools like Icarus Verilog by modeling its frequency scaling and locking behavior.
3. **Verification Suite**: A Cocotb test bench `test/test_hdmi_clk_gen.py` verifies the output periods and frequencies of both clocks, as well as the required 10:1 ratio.
4. **Integration**: The `run_tests.sh` script now automatically runs these new simulation tests, ensuring the clocking infrastructure remains verified.
5. **Documentation**: Updated the project roadmaps to reflect the completion of these goals.

Fixes #35

---
*PR created automatically by Jules for task [3139521206879799614](https://jules.google.com/task/3139521206879799614) started by @chatelao*