### PR TITLE
Implement HDMI 10:1 serializer and update roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 *$py.class
 
 # Cocotb / Simulation
-sim_build/
+sim_build*/
 results.xml
 *.vvp
 *.vcd

--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -8,7 +8,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Create behavioral PLL model for simulation.
 - [x] Implement Gowin `rPLL` hardware module for HDMI clock generation (Pixel/Serial clocks).
 - [x] Verify PLL clock outputs and lock signal in simulation.
-- [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
+- [x] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [ ] Map serializer outputs to differential pairs in the top-level design.
 - [ ] Integrate components into a top-level `hdmi_tx` module.
 - [ ] Connect `tt_um_vga_example` signals to the `hdmi_tx` core.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,11 +3,12 @@
 ## Current Goals
 - [ ] Define a basic Renode peripheral model for the TT APB bridge.
 - [ ] Verify APB bridge in Renode with UART echo firmware.
-- [x] Create behavioral PLL model for simulation.
-- [x] Implement Gowin `rPLL` hardware module.
-- [ ] Implement a 10:1 serializer module using Gowin OSER10 primitives.
+- [ ] Map serializer outputs to differential pairs in the top-level design.
+- [ ] Integrate components into a top-level `hdmi_tx` module.
+- [ ] Verify HDMI output timing and encoding via Cocotb simulation.
 
 ## Completed
+- [x] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.
 - [x] Assign physical pins for HDMI TMDS pairs in `src/top.cst`.
 - [x] Expand the APB expansion logic to support full 8-bit TT address space.
@@ -25,3 +26,5 @@
 - [x] Initialize Renode infrastructure placeholder.
 - [x] Fix test suite environment and synthesis scripts.
 - [x] Configure Renode to simulate the Tang Nano 4K and verify binaries (Correct peripherals implemented).
+- [x] Create behavioral PLL model for simulation.
+- [x] Implement Gowin `rPLL` hardware module.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -17,6 +17,15 @@ make -f cocotb_Makefile clean
 make -f cocotb_Makefile
 make -f Makefile.pll clean
 make -f Makefile.pll
+
+echo "--- Running Serializer Cocotb Test ---"
+rm -rf sim_build_serializer
+export PYTHONPATH=$PYTHONPATH:$(pwd)
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_serializer.v $(pwd)/oser10_sim_model.v" \
+    TOPLEVEL=hdmi_serializer \
+    MODULE=test_serializer \
+    SIM_BUILD=sim_build_serializer
 cd ..
 
 # 3. Synthesis Tests

--- a/sim_build_serializer/cmds.f
+++ b/sim_build_serializer/cmds.f
@@ -1,0 +1,1 @@
++timescale+1ns/1ps

--- a/src/hdmi_serializer.v
+++ b/src/hdmi_serializer.v
@@ -1,0 +1,96 @@
+/*
+ * HDMI Serializer for Tang Nano 4K (GW1NSR-LV4C)
+ *
+ * This module uses Gowin OSER10 primitives to serialize 10-bit TMDS words
+ * into a high-speed serial bitstream.
+ */
+
+`default_nettype none
+
+module hdmi_serializer (
+    input  wire       clk_pixel, // 25.2 MHz (Pixel Clock)
+    input  wire       clk_x10,   // 252 MHz  (Serial Clock)
+    input  wire       reset,     // Active high reset
+    input  wire [9:0] tmds_d0,   // Blue/Hsync/Vsync
+    input  wire [9:0] tmds_d1,   // Green/Control
+    input  wire [9:0] tmds_d2,   // Red/Control
+    input  wire [9:0] tmds_clk,  // TMDS Clock word (usually 10'b1111100000)
+    output wire       ser_d0,
+    output wire       ser_d1,
+    output wire       ser_d2,
+    output wire       ser_clk
+);
+
+    // Blue Channel (D0)
+    OSER10 oser_d0_inst (
+        .Q(ser_d0),
+        .D0(tmds_d0[0]),
+        .D1(tmds_d0[1]),
+        .D2(tmds_d0[2]),
+        .D3(tmds_d0[3]),
+        .D4(tmds_d0[4]),
+        .D5(tmds_d0[5]),
+        .D6(tmds_d0[6]),
+        .D7(tmds_d0[7]),
+        .D8(tmds_d0[8]),
+        .D9(tmds_d0[9]),
+        .PCLK(clk_pixel),
+        .FCLK(clk_x10),
+        .RESET(reset)
+    );
+
+    // Green Channel (D1)
+    OSER10 oser_d1_inst (
+        .Q(ser_d1),
+        .D0(tmds_d1[0]),
+        .D1(tmds_d1[1]),
+        .D2(tmds_d1[2]),
+        .D3(tmds_d1[3]),
+        .D4(tmds_d1[4]),
+        .D5(tmds_d1[5]),
+        .D6(tmds_d1[6]),
+        .D7(tmds_d1[7]),
+        .D8(tmds_d1[8]),
+        .D9(tmds_d1[9]),
+        .PCLK(clk_pixel),
+        .FCLK(clk_x10),
+        .RESET(reset)
+    );
+
+    // Red Channel (D2)
+    OSER10 oser_d2_inst (
+        .Q(ser_d2),
+        .D0(tmds_d2[0]),
+        .D1(tmds_d2[1]),
+        .D2(tmds_d2[2]),
+        .D3(tmds_d2[3]),
+        .D4(tmds_d2[4]),
+        .D5(tmds_d2[5]),
+        .D6(tmds_d2[6]),
+        .D7(tmds_d2[7]),
+        .D8(tmds_d2[8]),
+        .D9(tmds_d2[9]),
+        .PCLK(clk_pixel),
+        .FCLK(clk_x10),
+        .RESET(reset)
+    );
+
+    // TMDS Clock Channel
+    OSER10 oser_clk_inst (
+        .Q(ser_clk),
+        .D0(tmds_clk[0]),
+        .D1(tmds_clk[1]),
+        .D2(tmds_clk[2]),
+        .D3(tmds_clk[3]),
+        .D4(tmds_clk[4]),
+        .D5(tmds_clk[5]),
+        .D6(tmds_clk[6]),
+        .D7(tmds_clk[7]),
+        .D8(tmds_clk[8]),
+        .D9(tmds_clk[9]),
+        .PCLK(clk_pixel),
+        .FCLK(clk_x10),
+        .RESET(reset)
+    );
+
+endmodule

--- a/test/cocotb_Makefile
+++ b/test/cocotb_Makefile
@@ -1,10 +1,11 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/../src/tt_project.v
-VERILOG_SOURCES += $(PWD)/../src/hvsync_generator.v
+# Default sources, can be overridden
+VERILOG_SOURCES ?= $(PWD)/../src/tt_project.v $(PWD)/../src/hvsync_generator.v
 
-TOPLEVEL = tt_um_vga_example
-COCOTB_TEST_MODULES = test_tt_project
+# Default toplevel and module
+TOPLEVEL ?= tt_um_vga_example
+MODULE ?= test_tt_project
 
 include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/test/oser10_sim_model.v
+++ b/test/oser10_sim_model.v
@@ -1,0 +1,43 @@
+/*
+ * Behavioral model of Gowin OSER10 for simulation.
+ */
+
+`timescale 1ns/1ps
+
+module OSER10 (
+    output reg Q,
+    input wire D0, D1, D2, D3, D4, D5, D6, D7, D8, D9,
+    input wire PCLK,
+    input wire FCLK,
+    input wire RESET
+);
+
+    reg [9:0] latch;
+    reg [3:0] count;
+
+    // Use a helper to detect PCLK rising edge in FCLK domain
+    reg pclk_d;
+    always @(posedge FCLK) pclk_d <= PCLK;
+    wire pclk_rise = (PCLK && !pclk_d);
+
+    always @(posedge FCLK or posedge RESET) begin
+        if (RESET) begin
+            count <= 4'd0;
+            Q <= 1'b0;
+            latch <= 10'b0;
+        end else begin
+            if (pclk_rise) begin
+                latch <= {D9, D8, D7, D6, D5, D4, D3, D2, D1, D0};
+                Q <= D0;
+                count <= 4'd1;
+            end else begin
+                Q <= latch[count];
+                if (count == 4'd9)
+                    count <= 4'd0;
+                else
+                    count <= count + 4'd1;
+            end
+        end
+    end
+
+endmodule

--- a/test/sim_build_serializer/cmds.f
+++ b/test/sim_build_serializer/cmds.f
@@ -1,0 +1,1 @@
++timescale+1ns/1ps

--- a/test/test_serializer.py
+++ b/test/test_serializer.py
@@ -1,0 +1,57 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+import os
+
+@cocotb.test()
+async def test_serializer_basic(dut):
+    """Test basic serialization functionality"""
+
+    # Initialize clocks
+    # Pixel clock (25.2 MHz) -> period ~39.68 ns
+    # Serial clock (252 MHz) -> period ~3.968 ns
+    pixel_clk = Clock(dut.clk_pixel, 39.68, unit="ns")
+    serial_clk = Clock(dut.clk_x10, 3.968, unit="ns")
+
+    cocotb.start_soon(pixel_clk.start())
+    cocotb.start_soon(serial_clk.start())
+
+    # Reset
+    dut.reset.value = 1
+    dut.tmds_d0.value = 0
+    dut.tmds_d1.value = 0
+    dut.tmds_d2.value = 0
+    dut.tmds_clk.value = 0
+
+    await Timer(100, unit="ns")
+    await RisingEdge(dut.clk_pixel)
+    dut.reset.value = 0
+
+    # Wait for internal counter to reset and align
+    await RisingEdge(dut.clk_pixel)
+    await RisingEdge(dut.clk_x10)
+
+    # Test patterns
+    patterns = [
+        0b1010101010,
+        0b1111100000,
+        0b0000011111,
+        0x3FF,
+        0x000
+    ]
+
+    for p in patterns:
+        dut.tmds_d0.value = p
+        await RisingEdge(dut.clk_pixel)
+        # Wait a bit after pixel clock for the data to be latched in OSER10 model
+        await Timer(1, unit="ns")
+
+        # Check serialization (LSB first based on simulation model)
+        for i in range(10):
+            actual = dut.ser_d0.value
+            expected = (p >> i) & 1
+            assert actual == expected, f"Pattern {bin(p)} Bit {i} failed: expected {expected}, got {actual}"
+            await RisingEdge(dut.clk_x10)
+            await Timer(1, unit="ns")
+
+    await Timer(100, unit="ns")


### PR DESCRIPTION
This PR implements the 10:1 serializer module required for HDMI transmission on the Tang Nano 4K. It utilizes the Gowin OSER10 primitives to convert 10-bit parallel TMDS words into a serial bitstream. A behavioral simulation model for OSER10 is provided to enable full functional verification via Cocotb. The project roadmaps have been updated to reflect this progress and outline the next steps.

Fixes #37

---
*PR created automatically by Jules for task [14490633794324537277](https://jules.google.com/task/14490633794324537277) started by @chatelao*