### PR TITLE
Implement hdmi_tx top-level module and update roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -10,7 +10,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Verify PLL clock outputs and lock signal in simulation.
 - [x] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [ ] Map serializer outputs to differential pairs in the top-level design.
-- [ ] Integrate components into a top-level `hdmi_tx` module.
+- [x] Integrate components into a top-level `hdmi_tx` module.
 - [ ] Connect `tt_um_vga_example` signals to the `hdmi_tx` core.
 - [ ] Verify HDMI output timing and encoding via Cocotb simulation.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,11 @@
 - [ ] Define a basic Renode peripheral model for the TT APB bridge.
 - [ ] Verify APB bridge in Renode with UART echo firmware.
 - [ ] Map serializer outputs to differential pairs in the top-level design.
-- [ ] Integrate components into a top-level `hdmi_tx` module.
 - [ ] Verify HDMI output timing and encoding via Cocotb simulation.
+- [ ] Implement a Cocotb test bench for `hdmi_tx`.
 
 ## Completed
+- [x] Integrate components into a top-level `hdmi_tx` module.
 - [x] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.
 - [x] Assign physical pins for HDMI TMDS pairs in `src/top.cst`.

--- a/src/hdmi_tx.v
+++ b/src/hdmi_tx.v
@@ -1,0 +1,73 @@
+/*
+ * HDMI Transmitter Module for Tang Nano 4K
+ *
+ * This module integrates the TMDS encoders and the serializer to convert
+ * parallel RGB/Sync data into a high-speed TMDS bitstream.
+ */
+
+`default_nettype none
+
+module hdmi_tx (
+    input  wire       clk_pixel, // 25.2 MHz
+    input  wire       clk_x10,   // 252 MHz
+    input  wire       reset,
+    input  wire [7:0] red,
+    input  wire [7:0] green,
+    input  wire [7:0] blue,
+    input  wire       hsync,
+    input  wire       vsync,
+    input  wire       vde,
+    output wire       ser_clk,
+    output wire       ser_d0,
+    output wire       ser_d1,
+    output wire       ser_d2
+);
+
+    wire [9:0] tmds_d0;
+    wire [9:0] tmds_d1;
+    wire [9:0] tmds_d2;
+
+    // TMDS Encoders
+    tmds_encoder enc_blue (
+        .clk(clk_pixel),
+        .reset(reset),
+        .data(blue),
+        .ctrl({vsync, hsync}),
+        .vde(vde),
+        .tmds(tmds_d0)
+    );
+
+    tmds_encoder enc_green (
+        .clk(clk_pixel),
+        .reset(reset),
+        .data(green),
+        .ctrl(2'b00),
+        .vde(vde),
+        .tmds(tmds_d1)
+    );
+
+    tmds_encoder enc_red (
+        .clk(clk_pixel),
+        .reset(reset),
+        .data(red),
+        .ctrl(2'b00),
+        .vde(vde),
+        .tmds(tmds_d2)
+    );
+
+    // Serializer
+    hdmi_serializer serializer_inst (
+        .clk_pixel(clk_pixel),
+        .clk_x10(clk_x10),
+        .reset(reset),
+        .tmds_d0(tmds_d0),
+        .tmds_d1(tmds_d1),
+        .tmds_d2(tmds_d2),
+        .tmds_clk(10'b1111100000),
+        .ser_d0(ser_d0),
+        .ser_d1(ser_d1),
+        .ser_d2(ser_d2),
+        .ser_clk(ser_clk)
+    );
+
+endmodule


### PR DESCRIPTION
This PR implements the `hdmi_tx` top-level module, which is a key milestone in the VGA-to-HDMI adapter project. The module integrates three `tmds_encoder` instances (for R, G, and B) and an `hdmi_serializer` using Gowin OSER10 primitives. 

Key changes:
- New file: `src/hdmi_tx.v`
- Roadmap updates: `ROADMAP.md` and `MIGRATION_ROADMAP.md` marked integration as complete.
- Added a sub-task for Cocotb verification of the new transmitter module.

Verification:
- Structural verification passed.
- Synthesis of `hdmi_tx` verified with Yosys (`synth_gowin`).
- Existing VGA synthesis tests passed.

Fixes #39

---
*PR created automatically by Jules for task [13779473666975477112](https://jules.google.com/task/13779473666975477112) started by @chatelao*