### PR TITLE
Verify HDMI TX and Breakdown Roadmap Goals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ results.xml
 *.elf
 *.bin
 
+# Logs
+*.log
+
 # OS
 .DS_Store

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,16 @@
 # ROADMAP
 
 ## Current Goals
-- [ ] Define a basic Renode peripheral model for the TT APB bridge.
+- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
+- [ ] Integrate the TT APB bridge into `test/tang_nano_4k.repl`.
+- [ ] Develop a Renode test script to verify UART echo with the APB bridge.
 - [ ] Verify APB bridge in Renode with UART echo firmware.
-- [/] Map serializer outputs to differential pairs in the top-level design.
-- [ ] Verify HDMI output timing and encoding via Cocotb simulation.
-- [/] Implement a Cocotb test bench for `hdmi_tx`.
+- [ ] Implement audio support (1-bit PWM) in TMDS encoding.
 
 ## Completed
+- [x] Verify HDMI output timing and encoding via Cocotb simulation.
+- [x] Implement a Cocotb test bench for `hdmi_tx`.
+- [x] Map serializer outputs to differential pairs in the top-level design.
 - [x] Integrate components into a top-level `hdmi_tx` module.
 - [x] Implement a 10:1 serializer module using Gowin OSER10 primitives.
 - [x] Implement the TMDS 8b10b encoder logic in `src/tmds_encoder.v`.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -26,6 +26,14 @@ make -f cocotb_Makefile \
     TOPLEVEL=hdmi_serializer \
     MODULE=test_serializer \
     SIM_BUILD=sim_build_serializer
+
+echo "--- Running HDMI TX Cocotb Test ---"
+rm -rf sim_build_hdmi_tx
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_tx.v $(pwd)/../src/tmds_encoder.v $(pwd)/../src/hdmi_serializer.v $(pwd)/oser10_sim_model.v" \
+    TOPLEVEL=hdmi_tx \
+    MODULE=test_hdmi_tx \
+    SIM_BUILD=sim_build_hdmi_tx
 cd ..
 
 # 3. Synthesis Tests

--- a/test/test_hdmi_tx.py
+++ b/test/test_hdmi_tx.py
@@ -2,15 +2,7 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import RisingEdge, Timer
 
-@cocotb.test()
-async def test_hdmi_tx_basic(dut):
-    """Test basic HDMI TX functionality"""
-    pixel_clk = Clock(dut.clk_pixel, 39.68, unit="ns")
-    serial_clk = Clock(dut.clk_x10, 3.968, unit="ns")
-
-    cocotb.start_soon(pixel_clk.start())
-    cocotb.start_soon(serial_clk.start())
-
+async def reset_dut(dut):
     dut.reset.value = 1
     dut.red.value = 0
     dut.green.value = 0
@@ -18,11 +10,21 @@ async def test_hdmi_tx_basic(dut):
     dut.hsync.value = 0
     dut.vsync.value = 0
     dut.vde.value = 0
-
     await Timer(100, unit="ns")
     await RisingEdge(dut.clk_pixel)
     dut.reset.value = 0
     await RisingEdge(dut.clk_pixel)
+
+@cocotb.test()
+async def test_hdmi_tx_basic(dut):
+    """Test basic HDMI TX functionality and data transitions"""
+    pixel_clk = Clock(dut.clk_pixel, 39.68, unit="ns") # ~25.2 MHz
+    serial_clk = Clock(dut.clk_x10, 3.968, unit="ns") # ~252 MHz
+
+    cocotb.start_soon(pixel_clk.start())
+    cocotb.start_soon(serial_clk.start())
+
+    await reset_dut(dut)
 
     # Test some data
     dut.red.value = 0xFF
@@ -33,12 +35,18 @@ async def test_hdmi_tx_basic(dut):
     dut.vsync.value = 0
 
     await RisingEdge(dut.clk_pixel)
-    # Wait for serialization and check for activity
+    await RisingEdge(dut.clk_pixel) # Wait for pipeline
+
+    # Check for activity on serial lines
+    d0_seen_high = False
+    d0_seen_low = False
     for _ in range(20):
         await RisingEdge(dut.clk_x10)
-        # We expect some transitions on data lines
+        if dut.ser_d0.value == 1: d0_seen_high = True
+        if dut.ser_d0.value == 0: d0_seen_low = True
 
-    dut._log.info("HDMI TX test completed")
+    assert d0_seen_high and d0_seen_low, "No transitions seen on ser_d0 during data period"
+    dut._log.info("HDMI TX basic data test passed")
 
 @cocotb.test()
 async def test_hdmi_tx_control(dut):
@@ -49,49 +57,52 @@ async def test_hdmi_tx_control(dut):
     cocotb.start_soon(pixel_clk.start())
     cocotb.start_soon(serial_clk.start())
 
-    dut.reset.value = 1
-    await Timer(100, unit="ns")
-    await RisingEdge(dut.clk_pixel)
-    dut.reset.value = 0
-    await RisingEdge(dut.clk_pixel)
+    await reset_dut(dut)
 
+    # Control period: VDE=0
+    # Case: HSync=1, VSync=0 -> ctrl=2'b01
     dut.vde.value = 0
     dut.hsync.value = 1
     dut.vsync.value = 0
 
+    # Wait for pipeline (encoder has 1 cycle delay)
     await RisingEdge(dut.clk_pixel)
-    # Control signals should result in specific 10-bit patterns
-    # For Blue (D0), ctrl={vsync, hsync}=2'b01 -> 10'b0010101011
+    await RisingEdge(dut.clk_pixel)
 
-    await Timer(1, unit="ns")
-    # Check serialized output for D0
-    # Wait for the beginning of a serial cycle.
-    # In the OSER10 model, latching happens on PCLK rise.
-    while True:
-        await RisingEdge(dut.clk_x10)
-        if dut.serializer_inst.oser_d0_inst.count.value == 0:
-            break
+    # Synchronize to pixel clock edge to start capturing
+    await RisingEdge(dut.clk_pixel)
+    await Timer(1, unit="ns") # Offset from edge
 
     pattern = ""
     for _ in range(10):
         pattern += str(dut.ser_d0.value)
         await RisingEdge(dut.clk_x10)
+        await Timer(1, unit="ns")
 
-    # Serializer is LSB first
-    # Blue (D0), ctrl={vsync, hsync}=2'b01 -> 10'b0010101011
-    # expected_pattern = "1101010100" # Reversed 0010101011
-    # Actually, the TMDS encoders have a 1-clock delay for the pipeline.
-    # We might need to wait for one more pixel clock or just check if it matches ANY control symbol.
-    control_patterns = [
-        "1101010100", # 2'b00 -> 10'b0010101011 reversed
-        "0010101011", # 2'b01 -> 10'b1101010100 reversed (WAIT, I got them mixed up)
-        "1101010100", # 2'b00 -> 10'b0010101011 (LSB first: 0010101011 -> 1101010100)
-        "1101010100", # 00
-        "1101010100", # 00
-    ]
-    # Let's see what we actually got: 1110101010
-    # Wait, the 1110101010 is 0101010111 reversed.
-    # 2'b01 is 10'b0010101011. LSB first is 1101010100.
+    # ctrl=2'b01 -> tmds=10'b0010101011
+    # LSB first: 1, 1, 0, 1, 0, 1, 0, 1, 0, 0 -> "1101010100"
+    expected_pattern = "1101010100"
 
-    dut._log.info(f"Captured pattern: {pattern}")
-    # assert pattern == expected_pattern, f"Expected {expected_pattern}, got {pattern}"
+    dut._log.info(f"Captured pattern for ctrl=2'b01: {pattern}")
+    assert pattern == expected_pattern, f"Expected {expected_pattern}, got {pattern}"
+
+    # Case: HSync=0, VSync=0 -> ctrl=2'b00
+    dut.hsync.value = 0
+    await RisingEdge(dut.clk_pixel)
+    await RisingEdge(dut.clk_pixel)
+    await RisingEdge(dut.clk_pixel)
+    await Timer(1, unit="ns")
+
+    pattern = ""
+    for _ in range(10):
+        pattern += str(dut.ser_d0.value)
+        await RisingEdge(dut.clk_x10)
+        await Timer(1, unit="ns")
+
+    # ctrl=2'b00 -> tmds=10'b1101010100
+    # LSB first: 0, 0, 1, 0, 1, 0, 1, 0, 1, 1 -> "0010101011"
+    expected_pattern = "0010101011"
+    dut._log.info(f"Captured pattern for ctrl=2'b00: {pattern}")
+    assert pattern == expected_pattern, f"Expected {expected_pattern}, got {pattern}"
+
+    dut._log.info("HDMI TX control pattern test passed")


### PR DESCRIPTION
I have completed the verification of the HDMI transmitter and updated the project roadmap.

Key changes:
1.  **HDMI TX Verification**: Finalized `test/test_hdmi_tx.py` with accurate TMDS pattern checks (LSB-first) and proper synchronization. The test now successfully verifies both basic data transmission and control period symbols (e.g., sync pulses).
2.  **Test Suite Integration**: Added the `hdmi_tx` simulation to `run_tests.sh` so it runs automatically with the rest of the suite.
3.  **Environment Fix**: Installed missing `cocotb` and `cocotb-test` dependencies and updated `.gitignore` to exclude log files.
4.  **Roadmap Update**: Marked completed goals in `ROADMAP.md` and broke down the "Renode peripheral model" goal into three smaller, verifiable steps as requested.
5.  **Validation**: Verified that all structural, simulation, and synthesis tests pass by running the full `run_tests.sh` script.

Fixes #45

---
*PR created automatically by Jules for task [12600296459000613007](https://jules.google.com/task/12600296459000613007) started by @chatelao*