### PR TITLE
Refine roadmap goals for HDMI audio and Renode simulation

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -16,9 +16,8 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## Renode Simulation
 - [x] Correct Renode platform definition (`.repl`) to match CMSDK peripherals.
-- [ ] Define a basic Renode peripheral model for the TT APB bridge.
-- [ ] Verify APB bridge in Renode with UART echo firmware.
-- [ ] Create a Renode `.robot` test script to verify UART echo firmware.
+- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
+- [ ] Verify the TT APB bridge in Renode using a Robot test script.
 - [ ] Extend Renode simulation to verify TT module interaction via APB registers.
 - [ ] Integrate Renode verification into `run_tests.sh`.
 
@@ -32,8 +31,10 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 ## HDMI Audio Support
 - [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
-- [ ] Implement HDMI Audio Sample packet generation.
+- [ ] Implement BCH ECC encoders for HDMI packets.
+- [ ] Implement HDMI Packet Assembly logic for Data Islands.
 - [ ] Integrate Data Island periods into HDMI transmitter.
+- [ ] Implement HDMI Audio Sample packet generation.
 
 ## Automated E2E & Verification
 - [ ] Develop a Cocotb test bench for the complete `top` module.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,11 @@
 # ROADMAP
 
 ## Current Goals
-- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
-- [ ] Integrate the TT APB bridge into `test/tang_nano_4k.repl`.
-- [ ] Develop a Renode test script to verify UART echo with the APB bridge.
-- [ ] Implement HDMI Audio Sample packet generation.
+- [ ] Implement BCH ECC encoders for HDMI packets.
+- [ ] Implement HDMI Packet Assembly logic for Data Islands.
 - [ ] Integrate Data Island periods into HDMI transmitter.
+- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
+- [ ] Verify the TT APB bridge in Renode using a Robot test script.
 
 ## Completed
 - [x] Implement TERC4 encoder for HDMI Data Islands.


### PR DESCRIPTION
This change refines the project's roadmap by breaking down complex, high-level goals into smaller, more manageable steps. Specifically:
- The broad "HDMI Audio Sample packet generation" task is now split into implementing BCH ECC encoders, packet assembly logic, and transmitter integration.
- Renode simulation goals are now more focused on creating a Python-based peripheral model for the TT APB bridge and verifying it via Robot test scripts.
- Both `ROADMAP.md` and `MIGRATION_ROADMAP.md` have been synchronized to reflect these more granular steps.
- Existing tests were run to ensure no regressions in the project structure or simulations.

Fixes #51

---
*PR created automatically by Jules for task [3123136334373460829](https://jules.google.com/task/3123136334373460829) started by @chatelao*