### PR TITLE
Implement HDMI BCH ECC Encoders

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -32,7 +32,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.
-- [ ] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
+- [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [ ] Implement HDMI Packet Assembly logic for Data Islands.
 - [ ] Integrate Data Island periods into HDMI transmitter.
 - [ ] Implement HDMI Audio Sample packet generation.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current Goals
 - [x] Research and document BCH ECC parity equations for HDMI packets.
-- [ ] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
+- [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [ ] Implement HDMI Packet Assembly logic for Data Islands.
 - [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
 - [ ] Verify the TT APB bridge in Renode using a Robot test script.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,6 +37,19 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_tx \
     SIM_BUILD=sim_build_hdmi_tx
 
+echo "--- Running HDMI ECC Cocotb Test ---"
+rm -rf sim_build_hdmi_header_ecc sim_build_hdmi_subpacket_ecc
+make -f cocotb_Makefile clean
+MODULE=test_hdmi_ecc TESTCASE=test_hdmi_header_ecc make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_ecc.v" \
+    TOPLEVEL=hdmi_header_ecc \
+    SIM_BUILD=sim_build_hdmi_header_ecc
+make -f cocotb_Makefile clean
+MODULE=test_hdmi_ecc TESTCASE=test_hdmi_subpacket_ecc make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_ecc.v" \
+    TOPLEVEL=hdmi_subpacket_ecc \
+    SIM_BUILD=sim_build_hdmi_subpacket_ecc
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_ecc.v
+++ b/src/hdmi_ecc.v
@@ -1,0 +1,40 @@
+/*
+ * HDMI BCH ECC Encoders
+ *
+ * Implements BCH(32, 24) for Header and BCH(64, 56) for Subpackets.
+ * Generator Polynomial: G(x) = 1 + x + x^5 + x^6 + x^8 (0x163)
+ */
+
+`default_nettype none
+
+module hdmi_header_ecc (
+    input  wire [23:0] data,
+    output wire [7:0]  parity
+);
+
+    assign parity[0] = data[1] ^ data[2] ^ data[4] ^ data[8] ^ data[9] ^ data[10] ^ data[11] ^ data[13] ^ data[14] ^ data[15] ^ data[19] ^ data[20] ^ data[21] ^ data[23];
+    assign parity[1] = data[0] ^ data[2] ^ data[3] ^ data[4] ^ data[7] ^ data[11] ^ data[12] ^ data[15] ^ data[18] ^ data[21] ^ data[22] ^ data[23];
+    assign parity[2] = data[1] ^ data[2] ^ data[3] ^ data[6] ^ data[10] ^ data[11] ^ data[14] ^ data[17] ^ data[20] ^ data[21] ^ data[22];
+    assign parity[3] = data[0] ^ data[1] ^ data[2] ^ data[5] ^ data[9] ^ data[10] ^ data[13] ^ data[16] ^ data[19] ^ data[20] ^ data[21];
+    assign parity[4] = data[0] ^ data[1] ^ data[4] ^ data[8] ^ data[9] ^ data[12] ^ data[15] ^ data[18] ^ data[19] ^ data[20];
+    assign parity[5] = data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[7] ^ data[9] ^ data[10] ^ data[13] ^ data[15] ^ data[17] ^ data[18] ^ data[20] ^ data[21] ^ data[23];
+    assign parity[6] = data[0] ^ data[3] ^ data[4] ^ data[6] ^ data[10] ^ data[11] ^ data[12] ^ data[13] ^ data[15] ^ data[16] ^ data[17] ^ data[21] ^ data[22] ^ data[23];
+    assign parity[7] = data[2] ^ data[3] ^ data[5] ^ data[9] ^ data[10] ^ data[11] ^ data[12] ^ data[14] ^ data[15] ^ data[16] ^ data[20] ^ data[21] ^ data[22];
+
+endmodule
+
+module hdmi_subpacket_ecc (
+    input  wire [55:0] data,
+    output wire [7:0]  parity
+);
+
+    assign parity[0] = data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[6] ^ data[8] ^ data[13] ^ data[14] ^ data[15] ^ data[18] ^ data[19] ^ data[20] ^ data[21] ^ data[26] ^ data[27] ^ data[29] ^ data[30] ^ data[33] ^ data[34] ^ data[36] ^ data[40] ^ data[41] ^ data[42] ^ data[43] ^ data[45] ^ data[46] ^ data[47] ^ data[51] ^ data[52] ^ data[53] ^ data[55];
+    assign parity[1] = data[4] ^ data[5] ^ data[6] ^ data[7] ^ data[8] ^ data[12] ^ data[15] ^ data[17] ^ data[21] ^ data[25] ^ data[27] ^ data[28] ^ data[30] ^ data[32] ^ data[34] ^ data[35] ^ data[36] ^ data[39] ^ data[43] ^ data[44] ^ data[47] ^ data[50] ^ data[53] ^ data[54] ^ data[55];
+    assign parity[2] = data[3] ^ data[4] ^ data[5] ^ data[6] ^ data[7] ^ data[11] ^ data[14] ^ data[16] ^ data[20] ^ data[24] ^ data[26] ^ data[27] ^ data[29] ^ data[31] ^ data[33] ^ data[34] ^ data[35] ^ data[38] ^ data[42] ^ data[43] ^ data[46] ^ data[49] ^ data[52] ^ data[53] ^ data[54];
+    assign parity[3] = data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6] ^ data[10] ^ data[13] ^ data[15] ^ data[19] ^ data[23] ^ data[25] ^ data[26] ^ data[28] ^ data[30] ^ data[32] ^ data[33] ^ data[34] ^ data[37] ^ data[41] ^ data[42] ^ data[45] ^ data[48] ^ data[51] ^ data[52] ^ data[53];
+    assign parity[4] = data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[9] ^ data[12] ^ data[14] ^ data[18] ^ data[22] ^ data[24] ^ data[25] ^ data[27] ^ data[29] ^ data[31] ^ data[32] ^ data[33] ^ data[36] ^ data[40] ^ data[41] ^ data[44] ^ data[47] ^ data[50] ^ data[51] ^ data[52];
+    assign parity[5] = data[6] ^ data[11] ^ data[14] ^ data[15] ^ data[17] ^ data[18] ^ data[19] ^ data[20] ^ data[23] ^ data[24] ^ data[27] ^ data[28] ^ data[29] ^ data[31] ^ data[32] ^ data[33] ^ data[34] ^ data[35] ^ data[36] ^ data[39] ^ data[41] ^ data[42] ^ data[45] ^ data[47] ^ data[49] ^ data[50] ^ data[52] ^ data[53] ^ data[55];
+    assign parity[6] = data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[6] ^ data[8] ^ data[10] ^ data[15] ^ data[16] ^ data[17] ^ data[20] ^ data[21] ^ data[22] ^ data[23] ^ data[28] ^ data[29] ^ data[31] ^ data[32] ^ data[35] ^ data[36] ^ data[38] ^ data[42] ^ data[43] ^ data[44] ^ data[45] ^ data[47] ^ data[48] ^ data[49] ^ data[53] ^ data[54] ^ data[55];
+    assign parity[7] = data[0] ^ data[1] ^ data[2] ^ data[3] ^ data[4] ^ data[5] ^ data[7] ^ data[9] ^ data[14] ^ data[15] ^ data[16] ^ data[19] ^ data[20] ^ data[21] ^ data[22] ^ data[27] ^ data[28] ^ data[30] ^ data[31] ^ data[34] ^ data[35] ^ data[37] ^ data[41] ^ data[42] ^ data[43] ^ data[44] ^ data[46] ^ data[47] ^ data[48] ^ data[52] ^ data[53] ^ data[54];
+
+endmodule

--- a/test/test_hdmi_ecc.py
+++ b/test/test_hdmi_ecc.py
@@ -1,0 +1,54 @@
+import cocotb
+from cocotb.triggers import Timer
+import random
+
+def generate_hdmi_ecc_expected(data_int, num_bits):
+    # G(x) = x^8 + x^6 + x^5 + x + 1
+    # Polynomial: 0x63 (without the implicit x^8)
+    poly = 0x63
+    state = 0
+
+    for i in range(num_bits):
+        bit = (data_int >> i) & 1
+        feedback = bit ^ ((state >> 7) & 1)
+        state = (state << 1) & 0xFF
+        if feedback:
+            state ^= poly
+
+    return state
+
+@cocotb.test()
+async def test_hdmi_header_ecc(dut):
+    """Test HDMI Header ECC (BCH 32,24)"""
+
+    # Test cases: all zeros, all ones, and some random patterns
+    test_cases = [0, (1 << 24) - 1]
+    for _ in range(20):
+        test_cases.append(random.getrandbits(24))
+
+    for data in test_cases:
+        dut.data.value = data
+        await Timer(1, unit="ns")
+
+        expected = generate_hdmi_ecc_expected(data, 24)
+        actual = dut.parity.value.to_unsigned()
+
+        assert actual == expected, f"Header ECC error: Data={data:06x}, Expected={expected:02x}, Actual={actual:02x}"
+
+@cocotb.test()
+async def test_hdmi_subpacket_ecc(dut):
+    """Test HDMI Subpacket ECC (BCH 64,56)"""
+
+    # Test cases: all zeros, all ones, and some random patterns
+    test_cases = [0, (1 << 56) - 1]
+    for _ in range(20):
+        test_cases.append(random.getrandbits(56))
+
+    for data in test_cases:
+        dut.data.value = data
+        await Timer(1, unit="ns")
+
+        expected = generate_hdmi_ecc_expected(data, 56)
+        actual = dut.parity.value.to_unsigned()
+
+        assert actual == expected, f"Subpacket ECC error: Data={data:014x}, Expected={expected:02x}, Actual={actual:02x}"


### PR DESCRIPTION
This PR implements the HDMI BCH ECC encoders required for HDMI Data Island packets. It includes modules for both the 24-bit Header ECC and the 56-bit Subpacket ECC, along with a comprehensive test suite for verification.

Fixes #57

---
*PR created automatically by Jules for task [12856657832184423257](https://jules.google.com/task/12856657832184423257) started by @chatelao*