### PR TITLE
Implement HDMI Packet Packer and refine ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,10 @@
 ## Current Goals
 - [x] Research and document BCH ECC parity equations for HDMI packets.
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
-- [ ] Implement HDMI Packet Assembly logic for Data Islands.
+- [x] Implement HDMI Packet Packer (ECC calculation and bit mapping).
+- [ ] Implement HDMI Data Island State Machine (Guard bands, packet streaming).
+- [ ] Integrate Data Island support into `hdmi_tx`.
+- [ ] Implement Audio InfoFrame generation.
 - [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
 - [ ] Verify the TT APB bridge in Renode using a Robot test script.
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -50,6 +50,14 @@ MODULE=test_hdmi_ecc TESTCASE=test_hdmi_subpacket_ecc make -f cocotb_Makefile \
     TOPLEVEL=hdmi_subpacket_ecc \
     SIM_BUILD=sim_build_hdmi_subpacket_ecc
 
+echo "--- Running HDMI Packet Packer Cocotb Test ---"
+rm -rf sim_build_hdmi_packet_packer
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_packet_packer.v $(pwd)/../src/hdmi_ecc.v" \
+    TOPLEVEL=hdmi_packet_packer \
+    MODULE=test_hdmi_packet_packer \
+    SIM_BUILD=sim_build_hdmi_packet_packer
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_packet_packer.v
+++ b/src/hdmi_packet_packer.v
@@ -1,0 +1,72 @@
+/*
+ * HDMI Packet Packer
+ *
+ * Takes a packet header and 4 subpackets, calculates ECC,
+ * and maps them to the 32-pixel Data Island format.
+ *
+ * Based on HDMI 1.3a Section 5.4.3 and 5.4.4.
+ */
+
+`default_nettype none
+
+module hdmi_packet_packer (
+    input  wire [23:0] header_data,
+    input  wire [55:0] sub0_data,
+    input  wire [55:0] sub1_data,
+    input  wire [55:0] sub2_data,
+    input  wire [55:0] sub3_data,
+    input  wire [4:0]  pixel_index, // 0 to 31
+    output wire [3:0]  chan0_out,
+    output wire [3:0]  chan1_out,
+    output wire [3:0]  chan2_out
+);
+
+    wire [7:0] header_parity;
+    wire [7:0] sub0_parity;
+    wire [7:0] sub1_parity;
+    wire [7:0] sub2_parity;
+    wire [7:0] sub3_parity;
+
+    // ECC Encoders
+    hdmi_header_ecc ecc_header (
+        .data(header_data),
+        .parity(header_parity)
+    );
+
+    hdmi_subpacket_ecc ecc_sub0 (
+        .data(sub0_data),
+        .parity(sub0_parity)
+    );
+
+    hdmi_subpacket_ecc ecc_sub1 (
+        .data(sub1_data),
+        .parity(sub1_parity)
+    );
+
+    hdmi_subpacket_ecc ecc_sub2 (
+        .data(sub2_data),
+        .parity(sub2_parity)
+    );
+
+    hdmi_subpacket_ecc ecc_sub3 (
+        .data(sub3_data),
+        .parity(sub3_parity)
+    );
+
+    // Full 32-bit header and 64-bit subpackets
+    // Note: Specification says parity is appended after data.
+    // BCH(32,24): Header bits 0-23 are data, 24-31 are parity.
+    // BCH(64,56): Subpacket bits 0-55 are data, 56-63 are parity.
+    wire [31:0] header = {header_parity, header_data};
+    wire [63:0] sub0   = {sub0_parity,   sub0_data};
+    wire [63:0] sub1   = {sub1_parity,   sub1_data};
+    wire [63:0] sub2   = {sub2_parity,   sub2_data};
+    wire [63:0] sub3   = {sub3_parity,   sub3_data};
+
+    // Mapping to channels as per HDMI 1.3a Table 5-11
+    // Pixel i (0 to 31)
+    assign chan0_out = {sub2[pixel_index],    sub1[pixel_index],    sub0[pixel_index],    header[pixel_index]};
+    assign chan1_out = {sub3[pixel_index+32], sub2[pixel_index+32], sub1[pixel_index+32], sub0[pixel_index+32]};
+    assign chan2_out = {1'b0,                 1'b0,                 1'b0,                 sub3[pixel_index]};
+
+endmodule

--- a/test/test_hdmi_packet_packer.py
+++ b/test/test_hdmi_packet_packer.py
@@ -1,0 +1,97 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_hdmi_packet_packer(dut):
+    """Test HDMI Packet Packer mapping and ECC."""
+
+    # Sample packet data (Null Packet)
+    # Header: 24 bits (0x000000 for Null packet)
+    header_data = 0x000000
+    # Subpackets: 56 bits each
+    sub0_data = 0x0
+    sub1_data = 0x0
+    sub2_data = 0x0
+    sub3_data = 0x0
+
+    dut.header_data.value = header_data
+    dut.sub0_data.value = sub0_data
+    dut.sub1_data.value = sub1_data
+    dut.sub2_data.value = sub2_data
+    dut.sub3_data.value = sub3_data
+
+    await Timer(1, unit="ns")
+
+    # For Null packet (all 0s), parity should also be 0 since it's a linear code (XORs)
+    # Header parity = 0x00
+    # Subpacket parity = 0x00
+
+    # Check pixel 0 mapping
+    dut.pixel_index.value = 0
+    await Timer(1, unit="ns")
+
+    # header[0] = 0, sub0[0] = 0, sub1[0] = 0, sub2[0] = 0 -> chan0 = 0000
+    assert dut.chan0_out.value == 0x0
+    # sub0[32] = 0, sub1[32] = 0, sub2[32] = 0, sub3[32] = 0 -> chan1 = 0000
+    assert dut.chan1_out.value == 0x0
+    # sub3[0] = 0 -> chan2 = 0000
+    assert dut.chan2_out.value == 0x0
+
+    # Test with some data
+    header_data = 0x123456
+    sub0_data = 0x0123456789ABCD
+    sub1_data = 0x11223344556677
+    sub2_data = 0x8899AABBCCDDEE
+    sub3_data = 0xFFEEDDCCBBAA99
+
+    dut.header_data.value = header_data
+    dut.sub0_data.value = sub0_data
+    dut.sub1_data.value = sub1_data
+    dut.sub2_data.value = sub2_data
+    dut.sub3_data.value = sub3_data
+
+    await Timer(1, unit="ns")
+
+    # Parity will be calculated by the module
+    # We can check the mapping logic itself by reading internal signals if needed,
+    # or just trust the ECC modules (which are tested separately) and check bit positions.
+
+    header_parity = int(dut.ecc_header.parity.value)
+    sub0_parity = int(dut.ecc_sub0.parity.value)
+    sub1_parity = int(dut.ecc_sub1.parity.value)
+    sub2_parity = int(dut.ecc_sub2.parity.value)
+    sub3_parity = int(dut.ecc_sub3.parity.value)
+
+    header_full = (header_parity << 24) | header_data
+    sub0_full = (sub0_parity << 56) | sub0_data
+    sub1_full = (sub1_parity << 56) | sub1_data
+    sub2_full = (sub2_parity << 56) | sub2_data
+    sub3_full = (sub3_parity << 56) | sub3_data
+
+    for i in range(32):
+        dut.pixel_index.value = i
+        await Timer(1, unit="ns")
+
+        # chan0_out = {sub2[i], sub1[i], sub0[i], header[i]}
+        expected_chan0 = (
+            ((sub2_full >> i) & 1) << 3 |
+            ((sub1_full >> i) & 1) << 2 |
+            ((sub0_full >> i) & 1) << 1 |
+            ((header_full >> i) & 1)
+        )
+        assert int(dut.chan0_out.value) == expected_chan0
+
+        # chan1_out = {sub3[i+32], sub2[i+32], sub1[i+32], sub0[i+32]}
+        expected_chan1 = (
+            ((sub3_full >> (i+32)) & 1) << 3 |
+            ((sub2_full >> (i+32)) & 1) << 2 |
+            ((sub1_full >> (i+32)) & 1) << 1 |
+            ((sub0_full >> (i+32)) & 1)
+        )
+        assert int(dut.chan1_out.value) == expected_chan1
+
+        # chan2_out = {1'b0, 1'b0, 1'b0, sub3[i]}
+        expected_chan2 = (sub3_full >> i) & 1
+        assert int(dut.chan2_out.value) == expected_chan2
+
+    print("HDMI Packet Packer test passed!")


### PR DESCRIPTION
I have refined the project roadmap and implemented the first of the newly defined steps: the HDMI Packet Packer.

### Changes:
1.  **ROADMAP.md Refinement**: The broad goal of "HDMI Packet Assembly" was broken down into three smaller, more manageable tasks: Packet Packer, State Machine, and Integration. This allows for more granular progress tracking.
2.  **HDMI Packet Packer Implementation**: I created `src/hdmi_packet_packer.v`, which:
    *   Instantiates BCH(32,24) and BCH(64,56) ECC encoders for the packet header and four subpackets.
    *   Maps the 32-bit header and 256 bits of subpacket data (including parity) to the three TMDS channels over a 32-pixel Data Island period, following Table 5-11 of the HDMI 1.3a specification.
3.  **Verification**: 
    *   Developed a Cocotb test bench (`test/test_hdmi_packet_packer.py`) that verifies the bit mapping for every pixel index and ensures correct ECC integration.
    *   Updated the global `run_tests.sh` script to include this new test suite.
    *   Verified the RTL using Yosys to ensure it is synthesis-ready.
4.  **Goal Management**: Marked the Packet Packer as completed in the roadmap and added "Implement Audio InfoFrame generation" as a new goal to ensure the roadmap continues to provide a clear path forward with exactly 5 uncompleted 'Current Goals'.

Fixes #60

---
*PR created automatically by Jules for task [9122759525986582136](https://jules.google.com/task/9122759525986582136) started by @chatelao*