### PR TITLE
Implement HDMI Packet Framer and Update Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,16 @@
 # ROADMAP
 
 ## Current Goals
-- [x] Research and document BCH ECC parity equations for HDMI packets.
-- [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
-- [ ] Implement HDMI Packet Assembly logic for Data Islands.
+- [x] Implement HDMI Packet Framer with ECC integration.
+- [ ] Implement Data Island Serializer (32-cycle sequence).
+- [ ] Implement Data Island Guard Band and TERC4 multiplexing logic.
 - [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
 - [ ] Verify the TT APB bridge in Renode using a Robot test script.
+- [ ] Implement a basic HDMI Audio Clock Regeneration (N/CTS) packet generator.
 
 ## Completed
+- [x] Research and document BCH ECC parity equations for HDMI packets.
+- [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Verify TT APB bridge (`tt_m3_wrapper`) via Cocotb simulation.
 - [x] Verify HDMI output timing and encoding via Cocotb simulation.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -50,6 +50,15 @@ MODULE=test_hdmi_ecc TESTCASE=test_hdmi_subpacket_ecc make -f cocotb_Makefile \
     TOPLEVEL=hdmi_subpacket_ecc \
     SIM_BUILD=sim_build_hdmi_subpacket_ecc
 
+echo "--- Running HDMI Packet Framer Cocotb Test ---"
+rm -rf sim_build_hdmi_framer
+make -f cocotb_Makefile clean
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_packet_framer.v $(pwd)/../src/hdmi_ecc.v" \
+    TOPLEVEL=hdmi_packet_framer \
+    MODULE=test_hdmi_framer \
+    SIM_BUILD=sim_build_hdmi_framer
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_packet_framer.v
+++ b/src/hdmi_packet_framer.v
@@ -1,0 +1,68 @@
+/*
+ * HDMI Packet Framer
+ *
+ * This module takes raw header and subpacket data and integrates the ECC
+ * encoders to produce complete 32-bit headers and 64-bit subpackets.
+ *
+ * According to HDMI 1.3a Section 5.3.1:
+ * - Header is 32 bits (24 bits data + 8 bits ECC)
+ * - Each Subpacket is 64 bits (56 bits data + 8 bits ECC)
+ */
+
+`default_nettype none
+
+module hdmi_packet_framer (
+    input  wire [23:0] header_data,
+    input  wire [55:0] subpacket0_data,
+    input  wire [55:0] subpacket1_data,
+    input  wire [55:0] subpacket2_data,
+    input  wire [55:0] subpacket3_data,
+    output wire [31:0] header,
+    output wire [63:0] subpacket0,
+    output wire [63:0] subpacket1,
+    output wire [63:0] subpacket2,
+    output wire [63:0] subpacket3
+);
+
+    wire [7:0] header_parity;
+    wire [7:0] sp0_parity;
+    wire [7:0] sp1_parity;
+    wire [7:0] sp2_parity;
+    wire [7:0] sp3_parity;
+
+    // Header ECC
+    hdmi_header_ecc header_ecc_inst (
+        .data(header_data),
+        .parity(header_parity)
+    );
+    assign header = {header_parity, header_data};
+
+    // Subpacket 0 ECC
+    hdmi_subpacket_ecc sp0_ecc_inst (
+        .data(subpacket0_data),
+        .parity(sp0_parity)
+    );
+    assign subpacket0 = {sp0_parity, subpacket0_data};
+
+    // Subpacket 1 ECC
+    hdmi_subpacket_ecc sp1_ecc_inst (
+        .data(subpacket1_data),
+        .parity(sp1_parity)
+    );
+    assign subpacket1 = {sp1_parity, subpacket1_data};
+
+    // Subpacket 2 ECC
+    hdmi_subpacket_ecc sp2_ecc_inst (
+        .data(subpacket2_data),
+        .parity(sp2_parity)
+    );
+    assign subpacket2 = {sp2_parity, subpacket2_data};
+
+    // Subpacket 3 ECC
+    hdmi_subpacket_ecc sp3_ecc_inst (
+        .data(subpacket3_data),
+        .parity(sp3_parity)
+    );
+    assign subpacket3 = {sp3_parity, subpacket3_data};
+
+endmodule

--- a/test/test_hdmi_framer.py
+++ b/test/test_hdmi_framer.py
@@ -1,0 +1,47 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_hdmi_packet_framer(dut):
+    """Test HDMI Packet Framer ECC integration"""
+
+    # Example Null Packet (Type 0x00)
+    # Header: HB0=0x00, HB1=0x00, HB2=0x00 (24 bits)
+    # Subpackets: All zeros (56 bits each)
+
+    dut.header_data.value = 0x000000
+    dut.subpacket0_data.value = 0x00000000000000
+    dut.subpacket1_data.value = 0x00000000000000
+    dut.subpacket2_data.value = 0x00000000000000
+    dut.subpacket3_data.value = 0x00000000000000
+
+    await Timer(1, unit="ns")
+
+    # For all zeros, parity should be zero (G(x) has no constant term? No, parity of 0 is 0)
+    assert dut.header.value == 0x00000000
+    assert dut.subpacket0.value == 0x0000000000000000
+
+    # Example 2: Some data
+    # Header: 0x010203
+    dut.header_data.value = 0x010203
+    # Subpacket 0: 0x01020304050607
+    dut.subpacket0_data.value = 0x01020304050607
+
+    await Timer(1, unit="ns")
+
+    header_val = int(dut.header.value)
+    sp0_val = int(dut.subpacket0.value)
+
+    # Extract parity (top 8 bits)
+    header_parity = (header_val >> 24) & 0xFF
+    sp0_parity = (sp0_val >> 56) & 0xFF
+
+    dut._log.info(f"Header: {header_val:08x}, Parity: {header_parity:02x}")
+    dut._log.info(f"Subpacket 0: {sp0_val:016x}, Parity: {sp0_parity:02x}")
+
+    # Check that parity is non-zero for this data
+    assert header_parity != 0
+    assert sp0_parity != 0
+
+    # These parities should match what the BCH encoder generates.
+    # We already verified hdmi_ecc.v separately, so here we verify integration.


### PR DESCRIPTION
This PR implements the HDMI Packet Framer, a key component for HDMI Data Island support. It integrates existing ECC encoders to produce valid 32-bit headers and 64-bit subpackets. The change includes a new RTL module, a Cocotb test bench, and updates to the project roadmap and test suite.

Fixes #59

---
*PR created automatically by Jules for task [9177451912242516146](https://jules.google.com/task/9177451912242516146) started by @chatelao*