### PR TITLE
Implement HDMI Data Island FSM and refine roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -33,8 +33,9 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
-- [ ] Implement HDMI Packet Assembly logic for Data Islands.
-- [ ] Integrate Data Island periods into HDMI transmitter.
+- [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
+- [ ] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
+- [ ] Integrate Data Island support into `hdmi_tx`.
 - [ ] Implement HDMI Audio Sample packet generation.
 
 ## Automated E2E & Verification

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,14 @@
 # ROADMAP
 
 ## Current Goals
-- [ ] Implement HDMI Data Island FSM (Guard bands and timing control).
-- [ ] Implement HDMI Data Island Framer (Integration of Packet Packer and Guard Bands).
+- [ ] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
 - [ ] Integrate Data Island support into `hdmi_tx`.
 - [ ] Implement Audio InfoFrame generation.
+- [ ] Implement HDMI Audio Clock Regeneration (N/CTS) packet generation.
 - [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
 
 ## Completed
+- [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
 - [x] Implement HDMI Packet Packer (ECC calculation and bit mapping).
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [x] Research and document BCH ECC parity equations for HDMI packets.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -58,6 +58,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_packet_packer \
     SIM_BUILD=sim_build_hdmi_packet_packer
 
+echo "--- Running HDMI Data Island FSM Cocotb Test ---"
+rm -rf sim_build_hdmi_data_island_fsm
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_data_island_fsm.v" \
+    TOPLEVEL=hdmi_data_island_fsm \
+    MODULE=test_hdmi_data_island_fsm \
+    SIM_BUILD=sim_build_hdmi_data_island_fsm
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_data_island_fsm.v
+++ b/src/hdmi_data_island_fsm.v
@@ -1,0 +1,89 @@
+/*
+ * HDMI Data Island FSM
+ *
+ * Manages the timing for a single HDMI Data Island packet:
+ * - Preamble (8 pixels)
+ * - Leading Guard Band (2 pixels)
+ * - Data (32 pixels)
+ * - Trailing Guard Band (2 pixels)
+ *
+ * Based on HDMI 1.3a Section 5.4.1.
+ */
+
+`default_nettype none
+
+module hdmi_data_island_fsm (
+    input  wire       clk,
+    input  wire       reset,
+    input  wire       start,      // Trigger to start a packet sequence
+    output reg [2:0]  state,
+    output reg [4:0]  cnt,        // Internal counter for current state
+    output wire [4:0] packet_pixel_index, // 0-31 for hdmi_packet_packer
+    output wire       active      // High during any part of the sequence
+);
+
+    // States
+    localparam STATE_IDLE        = 3'd0;
+    localparam STATE_PREAMBLE    = 3'd1; // 8 pixels
+    localparam STATE_LEAD_GUARD  = 3'd2; // 2 pixels
+    localparam STATE_DATA        = 3'd3; // 32 pixels
+    localparam STATE_TRAIL_GUARD = 3'd4; // 2 pixels
+
+    assign active = (state != STATE_IDLE);
+    assign packet_pixel_index = (state == STATE_DATA) ? cnt : 5'd0;
+
+    always @(posedge clk) begin
+        if (reset) begin
+            state <= STATE_IDLE;
+            cnt   <= 5'd0;
+        end else begin
+            case (state)
+                STATE_IDLE: begin
+                    if (start) begin
+                        state <= STATE_PREAMBLE;
+                        cnt   <= 5'd0;
+                    end
+                end
+
+                STATE_PREAMBLE: begin
+                    if (cnt == 5'd7) begin
+                        state <= STATE_LEAD_GUARD;
+                        cnt   <= 5'd0;
+                    end else begin
+                        cnt <= cnt + 5'd1;
+                    end
+                end
+
+                STATE_LEAD_GUARD: begin
+                    if (cnt == 5'd1) begin
+                        state <= STATE_DATA;
+                        cnt   <= 5'd0;
+                    end else begin
+                        cnt <= cnt + 5'd1;
+                    end
+                end
+
+                STATE_DATA: begin
+                    if (cnt == 5'd31) begin
+                        state <= STATE_TRAIL_GUARD;
+                        cnt   <= 5'd0;
+                    end else begin
+                        cnt <= cnt + 5'd1;
+                    end
+                end
+
+                STATE_TRAIL_GUARD: begin
+                    if (cnt == 5'd1) begin
+                        state <= STATE_IDLE;
+                        cnt   <= 5'd0;
+                    end else begin
+                        cnt <= cnt + 5'd1;
+                    end
+                end
+
+                default: state <= STATE_IDLE;
+            endcase
+        end
+    end
+
+endmodule

--- a/test/test_hdmi_data_island_fsm.py
+++ b/test/test_hdmi_data_island_fsm.py
@@ -1,0 +1,66 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+
+@cocotb.test()
+async def test_hdmi_data_island_fsm(dut):
+    """Test HDMI Data Island FSM timing"""
+    clock = Clock(dut.clk, 40, unit="ns") # 25 MHz
+    cocotb.start_soon(clock.start())
+
+    # States from Verilog
+    STATE_IDLE = 0
+    STATE_PREAMBLE = 1
+    STATE_LEAD_GUARD = 2
+    STATE_DATA = 3
+    STATE_TRAIL_GUARD = 4
+
+    # Initial Reset
+    dut.reset.value = 1
+    dut.start.value = 0
+    await RisingEdge(dut.clk)
+    dut.reset.value = 0
+    await RisingEdge(dut.clk)
+
+    assert int(dut.state.value) == STATE_IDLE
+    assert int(dut.active.value) == 0
+
+    # Start sequence
+    dut.start.value = 1
+    await RisingEdge(dut.clk)
+    dut.start.value = 0
+
+    # Verify Preamble (8 pixels)
+    for i in range(8):
+        await Timer(1, unit="ns") # Allow combinational logic to settle
+        assert int(dut.state.value) == STATE_PREAMBLE
+        assert int(dut.cnt.value) == i
+        assert int(dut.active.value) == 1
+        await RisingEdge(dut.clk)
+
+    # Verify Leading Guard Band (2 pixels)
+    for i in range(2):
+        await Timer(1, unit="ns")
+        assert int(dut.state.value) == STATE_LEAD_GUARD
+        assert int(dut.cnt.value) == i
+        await RisingEdge(dut.clk)
+
+    # Verify Data (32 pixels)
+    for i in range(32):
+        await Timer(1, unit="ns")
+        assert int(dut.state.value) == STATE_DATA
+        assert int(dut.cnt.value) == i
+        assert int(dut.packet_pixel_index.value) == i
+        await RisingEdge(dut.clk)
+
+    # Verify Trailing Guard Band (2 pixels)
+    for i in range(2):
+        await Timer(1, unit="ns")
+        assert int(dut.state.value) == STATE_TRAIL_GUARD
+        assert int(dut.cnt.value) == i
+        await RisingEdge(dut.clk)
+
+    # Back to IDLE
+    await Timer(1, unit="ns")
+    assert int(dut.state.value) == STATE_IDLE
+    assert int(dut.active.value) == 0


### PR DESCRIPTION
Implemented the HDMI Data Island FSM, which manages the precise timing sequence (Preamble, Guard Bands, and Data) required for HDMI Data Island packets. Also refined the project roadmaps to provide a clearer path for the remaining HDMI and Renode tasks.

Fixes #65

---
*PR created automatically by Jules for task [12467381330462306523](https://jules.google.com/task/12467381330462306523) started by @chatelao*