### PR TITLE
Implement HDMI Data Island Framer

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -34,7 +34,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Research and document BCH ECC parity equations for HDMI packets.
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
-- [ ] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
+- [x] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
 - [ ] Integrate Data Island support into `hdmi_tx`.
 - [ ] Implement HDMI Audio Sample packet generation.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # ROADMAP
 
 ## Current Goals
-- [ ] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
+- [x] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
 - [ ] Integrate Data Island support into `hdmi_tx`.
 - [ ] Implement Audio InfoFrame generation.
 - [ ] Implement HDMI Audio Clock Regeneration (N/CTS) packet generation.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -66,6 +66,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_data_island_fsm \
     SIM_BUILD=sim_build_hdmi_data_island_fsm
 
+echo "--- Running HDMI Data Island Framer Cocotb Test ---"
+rm -rf sim_build_hdmi_data_island_framer
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_data_island_framer.v $(pwd)/../src/hdmi_data_island_fsm.v $(pwd)/../src/hdmi_packet_packer.v $(pwd)/../src/hdmi_ecc.v $(pwd)/../src/terc4_encoder.v" \
+    TOPLEVEL=hdmi_data_island_framer \
+    MODULE=test_hdmi_data_island_framer \
+    SIM_BUILD=sim_build_hdmi_data_island_framer
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_data_island_framer.v
+++ b/src/hdmi_data_island_framer.v
@@ -1,0 +1,108 @@
+/*
+ * HDMI Data Island Framer
+ *
+ * Integrates the FSM, Packet Packer, and TERC4 encoders to
+ * produce the full 44-pixel Data Island sequence.
+ */
+
+`default_nettype none
+
+module hdmi_data_island_framer (
+    input  wire        clk,
+    input  wire        reset,
+    input  wire        start,
+    input  wire [23:0] header_data,
+    input  wire [55:0] sub0_data,
+    input  wire [55:0] sub1_data,
+    input  wire [55:0] sub2_data,
+    input  wire [55:0] sub3_data,
+    input  wire        hsync,
+    input  wire        vsync,
+    output reg  [9:0]  chan0_tmds,
+    output reg  [9:0]  chan1_tmds,
+    output reg  [9:0]  chan2_tmds,
+    output wire        active
+);
+
+    // States from FSM
+    localparam STATE_IDLE        = 3'd0;
+    localparam STATE_PREAMBLE    = 3'd1;
+    localparam STATE_LEAD_GUARD  = 3'd2;
+    localparam STATE_DATA        = 3'd3;
+    localparam STATE_TRAIL_GUARD = 3'd4;
+
+    wire [2:0] state;
+    wire [4:0] cnt;
+    wire [4:0] packet_pixel_index;
+
+    hdmi_data_island_fsm fsm_inst (
+        .clk(clk),
+        .reset(reset),
+        .start(start),
+        .state(state),
+        .cnt(cnt),
+        .packet_pixel_index(packet_pixel_index),
+        .active(active)
+    );
+
+    wire [3:0] packer_chan0, packer_chan1, packer_chan2;
+    hdmi_packet_packer packer_inst (
+        .header_data(header_data),
+        .sub0_data(sub0_data),
+        .sub1_data(sub1_data),
+        .sub2_data(sub2_data),
+        .sub3_data(sub3_data),
+        .hsync(hsync),
+        .vsync(vsync),
+        .pixel_index(packet_pixel_index),
+        .chan0_out(packer_chan0),
+        .chan1_out(packer_chan1),
+        .chan2_out(packer_chan2)
+    );
+
+    wire [9:0] terc4_chan0, terc4_chan1, terc4_chan2;
+    terc4_encoder enc0 (.data(packer_chan0), .tmds(terc4_chan0));
+    terc4_encoder enc1 (.data(packer_chan1), .tmds(terc4_chan1));
+    terc4_encoder enc2 (.data(packer_chan2), .tmds(terc4_chan2));
+
+    // Control Symbols
+    function [9:0] get_ctrl_symbol(input [1:0] ctrl);
+        case (ctrl)
+            2'b00:   get_ctrl_symbol = 10'b1101010100;
+            2'b01:   get_ctrl_symbol = 10'b0010101011;
+            2'b10:   get_ctrl_symbol = 10'b0101010100;
+            default: get_ctrl_symbol = 10'b1010101100;
+        endcase
+    endfunction
+
+    always @(*) begin
+        case (state)
+            STATE_PREAMBLE: begin
+                // Data Island Preamble: CTL0=1, CTL1=0, CTL2=1, CTL3=0
+                // CTL0/1 on Channel 1, CTL2/3 on Channel 2
+                chan0_tmds = get_ctrl_symbol({vsync, hsync});
+                chan1_tmds = 10'b0010101011; // CTL 2'b01
+                chan2_tmds = 10'b0010101011; // CTL 2'b01
+            end
+
+            STATE_LEAD_GUARD, STATE_TRAIL_GUARD: begin
+                chan0_tmds = 10'b1011001100;
+                chan1_tmds = 10'b0100110011;
+                chan2_tmds = 10'b0100110011;
+            end
+
+            STATE_DATA: begin
+                chan0_tmds = terc4_chan0;
+                chan1_tmds = terc4_chan1;
+                chan2_tmds = terc4_chan2;
+            end
+
+            default: begin
+                chan0_tmds = 10'b0;
+                chan1_tmds = 10'b0;
+                chan2_tmds = 10'b0;
+            end
+        endcase
+    end
+
+endmodule

--- a/src/hdmi_packet_packer.v
+++ b/src/hdmi_packet_packer.v
@@ -15,6 +15,8 @@ module hdmi_packet_packer (
     input  wire [55:0] sub1_data,
     input  wire [55:0] sub2_data,
     input  wire [55:0] sub3_data,
+    input  wire        hsync,
+    input  wire        vsync,
     input  wire [4:0]  pixel_index, // 0 to 31
     output wire [3:0]  chan0_out,
     output wire [3:0]  chan1_out,
@@ -64,9 +66,11 @@ module hdmi_packet_packer (
     wire [63:0] sub3   = {sub3_parity,   sub3_data};
 
     // Mapping to channels as per HDMI 1.3a Table 5-11
-    // Pixel i (0 to 31)
-    assign chan0_out = {sub2[pixel_index],    sub1[pixel_index],    sub0[pixel_index],    header[pixel_index]};
-    assign chan1_out = {sub3[pixel_index+32], sub2[pixel_index+32], sub1[pixel_index+32], sub0[pixel_index+32]};
-    assign chan2_out = {1'b0,                 1'b0,                 1'b0,                 sub3[pixel_index]};
+    // Channel 0: [0, VSync, HSync, Header bit]
+    assign chan0_out = {1'b0, vsync, hsync, header[pixel_index]};
+    // Channel 1: [Subpacket 1 bit i+32, Subpacket 0 bit i+32, Subpacket 1 bit i, Subpacket 0 bit i]
+    assign chan1_out = {sub1[pixel_index+32], sub0[pixel_index+32], sub1[pixel_index], sub0[pixel_index]};
+    // Channel 2: [Subpacket 3 bit i+32, Subpacket 2 bit i+32, Subpacket 3 bit i, Subpacket 2 bit i]
+    assign chan2_out = {sub3[pixel_index+32], sub2[pixel_index+32], sub3[pixel_index], sub2[pixel_index]};
 
 endmodule

--- a/test/test_hdmi_data_island_framer.py
+++ b/test/test_hdmi_data_island_framer.py
@@ -1,0 +1,64 @@
+import cocotb
+from cocotb.triggers import RisingEdge, Timer
+from cocotb.clock import Clock
+
+@cocotb.test()
+async def test_hdmi_data_island_framer(dut):
+    """Test HDMI Data Island Framer sequence and encoding"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.reset.value = 1
+    dut.start.value = 0
+    dut.header_data.value = 0
+    dut.sub0_data.value = 0
+    dut.sub1_data.value = 0
+    dut.sub2_data.value = 0
+    dut.sub3_data.value = 0
+    dut.hsync.value = 0
+    dut.vsync.value = 0
+
+    await RisingEdge(dut.clk)
+    dut.reset.value = 0
+    await RisingEdge(dut.clk)
+
+    # Start sequence
+    dut.start.value = 1
+    await RisingEdge(dut.clk)
+    dut.start.value = 0
+
+    # Allow logic to settle after clock edge
+    await Timer(1, unit="ns")
+
+    # Verify Preamble (8 pixels)
+    for i in range(8):
+        assert int(dut.active.value) == 1, f"Expected active at preamble pixel {i}"
+        # In Preamble, chan1 uses CTL 2'b01 -> 10'b0010101011
+        assert int(dut.chan1_tmds.value) == 0b0010101011
+        # In Preamble, chan2 uses CTL 2'b01 -> 10'b0010101011
+        assert int(dut.chan2_tmds.value) == 0b0010101011
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+
+    # Verify Leading Guard Band (2 pixels)
+    for i in range(2):
+        assert int(dut.chan0_tmds.value) == 0b1011001100, f"Expected lead guard on chan0 at pixel {i}"
+        assert int(dut.chan1_tmds.value) == 0b0100110011
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+
+    # Verify Data (32 pixels)
+    for i in range(32):
+        # Since data is all 0, TERC4(0) = 10'b1010011100
+        assert int(dut.chan0_tmds.value) == 0b1010011100, f"Expected data TERC4 on chan0 at pixel {i}, got {int(dut.chan0_tmds.value):010b}"
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+
+    # Verify Trailing Guard Band (2 pixels)
+    for i in range(2):
+        assert int(dut.chan0_tmds.value) == 0b1011001100, f"Expected trail guard on chan0 at pixel {i}"
+        await RisingEdge(dut.clk)
+        await Timer(1, unit="ns")
+
+    assert int(dut.active.value) == 0
+    print("HDMI Data Island Framer test passed!")

--- a/test/test_hdmi_packet_packer.py
+++ b/test/test_hdmi_packet_packer.py
@@ -19,25 +19,31 @@ async def test_hdmi_packet_packer(dut):
     dut.sub1_data.value = sub1_data
     dut.sub2_data.value = sub2_data
     dut.sub3_data.value = sub3_data
+    dut.hsync.value = 0
+    dut.vsync.value = 0
 
     await Timer(1, unit="ns")
 
-    # For Null packet (all 0s), parity should also be 0 since it's a linear code (XORs)
-    # Header parity = 0x00
-    # Subpacket parity = 0x00
-
+    # For Null packet (all 0s), parity should also be 0
     # Check pixel 0 mapping
     dut.pixel_index.value = 0
     await Timer(1, unit="ns")
 
-    # header[0] = 0, sub0[0] = 0, sub1[0] = 0, sub2[0] = 0 -> chan0 = 0000
+    # chan0 = {0, vsync, hsync, header[0]} = 0000
     assert dut.chan0_out.value == 0x0
-    # sub0[32] = 0, sub1[32] = 0, sub2[32] = 0, sub3[32] = 0 -> chan1 = 0000
+    # chan1 = {sub1[32], sub0[32], sub1[0], sub0[0]} = 0000
     assert dut.chan1_out.value == 0x0
-    # sub3[0] = 0 -> chan2 = 0000
+    # chan2 = {sub3[32], sub2[32], sub3[0], sub2[0]} = 0000
     assert dut.chan2_out.value == 0x0
 
-    # Test with some data
+    # Test with Sync signals
+    dut.hsync.value = 1
+    dut.vsync.value = 0
+    await Timer(1, unit="ns")
+    # chan0 = {0, 0, 1, 0} = 0x2
+    assert dut.chan0_out.value == 0x2
+
+    # Test with data
     header_data = 0x123456
     sub0_data = 0x0123456789ABCD
     sub1_data = 0x11223344556677
@@ -51,10 +57,6 @@ async def test_hdmi_packet_packer(dut):
     dut.sub3_data.value = sub3_data
 
     await Timer(1, unit="ns")
-
-    # Parity will be calculated by the module
-    # We can check the mapping logic itself by reading internal signals if needed,
-    # or just trust the ECC modules (which are tested separately) and check bit positions.
 
     header_parity = int(dut.ecc_header.parity.value)
     sub0_parity = int(dut.ecc_sub0.parity.value)
@@ -72,26 +74,31 @@ async def test_hdmi_packet_packer(dut):
         dut.pixel_index.value = i
         await Timer(1, unit="ns")
 
-        # chan0_out = {sub2[i], sub1[i], sub0[i], header[i]}
+        # chan0_out = {1'b0, vsync, hsync, header[i]}
         expected_chan0 = (
-            ((sub2_full >> i) & 1) << 3 |
-            ((sub1_full >> i) & 1) << 2 |
-            ((sub0_full >> i) & 1) << 1 |
+            (0 << 3) |
+            (int(dut.vsync.value) << 2) |
+            (int(dut.hsync.value) << 1) |
             ((header_full >> i) & 1)
         )
         assert int(dut.chan0_out.value) == expected_chan0
 
-        # chan1_out = {sub3[i+32], sub2[i+32], sub1[i+32], sub0[i+32]}
+        # chan1_out = {sub1[i+32], sub0[i+32], sub1[i], sub0[i]}
         expected_chan1 = (
-            ((sub3_full >> (i+32)) & 1) << 3 |
-            ((sub2_full >> (i+32)) & 1) << 2 |
-            ((sub1_full >> (i+32)) & 1) << 1 |
-            ((sub0_full >> (i+32)) & 1)
+            ((sub1_full >> (i+32)) & 1) << 3 |
+            ((sub0_full >> (i+32)) & 1) << 2 |
+            ((sub1_full >> i) & 1) << 1 |
+            ((sub0_full >> i) & 1)
         )
         assert int(dut.chan1_out.value) == expected_chan1
 
-        # chan2_out = {1'b0, 1'b0, 1'b0, sub3[i]}
-        expected_chan2 = (sub3_full >> i) & 1
+        # chan2_out = {sub3[i+32], sub2[i+32], sub3[i], sub2[i]}
+        expected_chan2 = (
+            ((sub3_full >> (i+32)) & 1) << 3 |
+            ((sub2_full >> (i+32)) & 1) << 2 |
+            ((sub3_full >> i) & 1) << 1 |
+            ((sub2_full >> i) & 1)
+        )
         assert int(dut.chan2_out.value) == expected_chan2
 
     print("HDMI Packet Packer test passed!")


### PR DESCRIPTION
This change implements the HDMI Data Island Framer, a key component for transmitting non-video data (like audio or info-frames) over HDMI. It integrates the FSM, Packet Packer, and TERC4 encoders to handle the specific timing and encoding requirements of HDMI Data Island periods.

Key changes:
- **`src/hdmi_packet_packer.v`**: Updated to follow the bit mapping specified in HDMI 1.3a Table 5-11, ensuring correct distribution of header and subpacket bits across TMDS channels. Added HSync and VSync inputs to be carried in Channel 0 during the data period.
- **`src/hdmi_data_island_framer.v`**: New module that manages the 44-pixel Data Island sequence (8 pixels preamble, 2 pixels leading guard band, 32 pixels data, 2 pixels trailing guard band). It handles the state-based multiplexing of control symbols, guard band symbols, and TERC4-encoded packet data.
- **`test/test_hdmi_data_island_framer.py`**: New Cocotb test bench verifying the full sequence and the correct 10-bit symbols for each state.
- **`test/test_hdmi_packet_packer.py`**: Updated to match the new bit mapping and verify sync signal propagation.
- **`run_tests.sh`**: Integrated the new framer test into the automated suite.
- **Roadmaps**: Marked the framer implementation as complete in `ROADMAP.md` and `MIGRATION_ROADMAP.md`.

Fixes #67

---
*PR created automatically by Jules for task [6582424870232418732](https://jules.google.com/task/6582424870232418732) started by @chatelao*