### PR TITLE
Granular Roadmap Breakdown for HDMI and Renode Support

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -16,9 +16,10 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## Renode Simulation
 - [x] Correct Renode platform definition (`.repl`) to match CMSDK peripherals.
-- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
-- [ ] Verify the TT APB bridge in Renode using a Robot test script.
-- [ ] Extend Renode simulation to verify TT module interaction via APB registers.
+- [ ] Define the Python peripheral class for the Tiny Tapeout APB bridge in Renode.
+- [ ] Implement register read/write logic in the Renode model matching `tt_wrapper.v`.
+- [ ] Integrate a behavioral model of the TT design into the Renode peripheral.
+- [ ] Create a Robot test script to verify M3-to-TT interaction in Renode.
 - [ ] Integrate Renode verification into `run_tests.sh`.
 
 ## APB Expansion & Bridge
@@ -28,7 +29,12 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [ ] Update `m3_regs.h` with additional TT control/status registers if needed.
 - [ ] Implement firmware-based read-back verification for all TT registers.
 
-## HDMI Audio Support
+## HDMI Audio & Data Island Packets
+- [ ] Research and document HDMI ACR (Type 0x01) and InfoFrame (AVI/Audio) byte layouts.
+- [ ] Implement InfoFrame Checksum calculation logic.
+- [ ] Implement AVI InfoFrame generator (Type 0x82) for 640x480p.
+- [ ] Implement Audio Clock Regeneration (ACR) packet generator (Type 0x01).
+- [ ] Implement a Data Island Packet Scheduler to multiplex multiple packet types.
 - [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,11 @@
 # ROADMAP
 
 ## Current Goals
-- [x] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
-- [x] Integrate Data Island support into `hdmi_tx`.
-- [ ] Implement Audio InfoFrame generation.
-- [ ] Implement HDMI Audio Clock Regeneration (N/CTS) packet generation.
+- [ ] Research and document HDMI ACR and InfoFrame bit layouts.
+- [ ] Implement HDMI AVI InfoFrame generation.
+- [ ] Implement HDMI Audio Clock Regeneration (ACR) packet generation.
+- [ ] Implement Data Island Packet Scheduler.
 - [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
-- [ ] Implement HDMI Audio Sample packet generation.
-- [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 
 ## Completed
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).


### PR DESCRIPTION
I have decomposed the high-level project goals into more modest, feasible, and verifiable sub-tasks in `ROADMAP.md` and `MIGRATION_ROADMAP.md`. 

Key changes:
1.  **HDMI Audio & Data Island**: Broken down into research (bit layouts), checksum logic implementation, specific packet generators (ACR/AVI), and packet scheduling.
2.  **Renode Simulation**: Broken down into peripheral class definition, register logic implementation, behavioral model integration, and Robot testing.
3.  **ROADMAP.md**: Cleaned up the "Current Goals" section to focus on the next immediate steps while preserving exactly 5 uncompleted items.

All existing Cocotb simulation and synthesis tests pass.

Fixes #71

---
*PR created automatically by Jules for task [4685434534440883674](https://jules.google.com/task/4685434534440883674) started by @chatelao*