### PR TITLE
Decompose high-level roadmap goals into modest steps

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -16,6 +16,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## Renode Simulation
 - [x] Correct Renode platform definition (`.repl`) to match CMSDK peripherals.
+- [ ] Implement basic APB register logic in Renode Python model.
 - [ ] Define the Python peripheral class for the Tiny Tapeout APB bridge in Renode.
 - [ ] Implement register read/write logic in the Renode model matching `tt_wrapper.v`.
 - [ ] Integrate a behavioral model of the TT design into the Renode peripheral.
@@ -30,11 +31,13 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [ ] Implement firmware-based read-back verification for all TT registers.
 
 ## HDMI Audio & Data Island Packets
-- [ ] Research and document HDMI ACR (Type 0x01) and InfoFrame (AVI/Audio) byte layouts.
+- [ ] Research and document HDMI ACR and InfoFrame byte layouts.
 - [ ] Implement InfoFrame Checksum calculation logic.
-- [ ] Implement AVI InfoFrame generator (Type 0x82) for 640x480p.
-- [ ] Implement Audio Clock Regeneration (ACR) packet generator (Type 0x01).
-- [ ] Implement a Data Island Packet Scheduler to multiplex multiple packet types.
+- [ ] Implement AVI InfoFrame generator for 640x480p.
+- [ ] Implement Audio Clock Regeneration (ACR) packet generator.
+- [ ] Define Data Island Packet interface and basic arbiter.
+- [ ] Implement scanline-based trigger logic for Data Island packets.
+- [ ] Multiplex AVI InfoFrame and ACR packets in the scheduler.
 - [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,10 @@
 
 ## Current Goals
 - [ ] Research and document HDMI ACR and InfoFrame bit layouts.
-- [ ] Implement HDMI AVI InfoFrame generation.
+- [ ] Implement InfoFrame Checksum calculation logic.
+- [ ] Implement basic APB register logic in Renode Python model.
+- [ ] Define packet interface and basic arbiter for Data Island.
 - [ ] Implement HDMI Audio Clock Regeneration (ACR) packet generation.
-- [ ] Implement Data Island Packet Scheduler.
-- [ ] Create a Python-based Renode peripheral model for the TT APB bridge.
 
 ## Completed
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).


### PR DESCRIPTION
I have updated the project's roadmap files (`ROADMAP.md` and `MIGRATION_ROADMAP.md`) to decompose several broad, high-level goals into more modest, feasible, and verifiable steps. 

Specifically:
- The **Data Island Packet Scheduler** goal was broken down into defining the packet interface, implementing scanline-based triggers, and multiplexing AVI/ACR packets.
- The **Renode peripheral model** goal was decomposed into implementing basic APB register logic, defining the Python class, and integrating behavioral models.
- A new modest goal for **InfoFrame Checksum calculation logic** was added as a prerequisite for AVI InfoFrame generation.
- Unverified constants and broad implementation tasks for AVI and ACR packets were replaced with more general research and implementation steps to ensure groundedness in future tasks.

These changes provide a clearer and more actionable path for the project's next development phases while maintaining the repository's documentation standards. All existing project tests pass.

Fixes #73

---
*PR created automatically by Jules for task [17548406821059631116](https://jules.google.com/task/17548406821059631116) started by @chatelao*