### PR TITLE
Document HDMI packets and implement InfoFrame checksum

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -31,8 +31,8 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [ ] Implement firmware-based read-back verification for all TT registers.
 
 ## HDMI Audio & Data Island Packets
-- [ ] Research and document HDMI ACR and InfoFrame byte layouts.
-- [ ] Implement InfoFrame Checksum calculation logic.
+- [x] Research and document HDMI ACR and InfoFrame byte layouts.
+- [x] Implement InfoFrame Checksum calculation logic.
 - [ ] Implement AVI InfoFrame generator for 640x480p.
 - [ ] Implement Audio Clock Regeneration (ACR) packet generator.
 - [ ] Define Data Island Packet interface and basic arbiter.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # ROADMAP
 
 ## Current Goals
-- [ ] Research and document HDMI ACR and InfoFrame bit layouts.
-- [ ] Implement InfoFrame Checksum calculation logic.
+- [x] Research and document HDMI ACR and InfoFrame bit layouts.
+- [x] Implement InfoFrame Checksum calculation logic.
 - [ ] Implement basic APB register logic in Renode Python model.
 - [ ] Define packet interface and basic arbiter for Data Island.
 - [ ] Implement HDMI Audio Clock Regeneration (ACR) packet generation.

--- a/definitions/hdmi_packets.md
+++ b/definitions/hdmi_packets.md
@@ -1,0 +1,52 @@
+# HDMI Data Island Packet Layouts
+
+This document describes the byte-level layouts for specific HDMI Data Island packets.
+
+## 1. Auxiliary Video Information (AVI) InfoFrame
+Used to inform the sink about the video format, color space, and aspect ratio.
+
+- **Packet Type**: 0x82
+- **Version**: 0x02
+- **Length**: 13 bytes (0x0D)
+
+### Header
+- **HB0**: 0x82 (Packet Type)
+- **HB1**: 0x02 (Version)
+- **HB2**: 0x0D (Length)
+
+### Data Bytes
+- **DB1**: Checksum (8-bit sum of all header and data bytes must be 0 mod 256)
+- **DB2**: [7:7] Reserved, [6:5] Y1Y0 (RGB/YUV), [4:4] A0 (Active Format Info), [3:2] B1B0 (Bar Info), [1:0] S1S0 (Scan Info)
+- **DB3**: [7:6] C1C0 (Colorimetry), [5:4] M1M0 (Aspect Ratio), [3:0] R3R0 (Active Format Aspect Ratio)
+- **DB4**: [7:7] ITC (IT Content), [6:4] EC2EC0 (Extended Colorimetry), [3:2] Q1Q0 (Quantization Range), [1:0] SC1SC0 (Non-uniform Picture Scaling)
+- **DB5**: [7:0] VIC (Video Identification Code) - e.g., 1 for 640x480p
+- **DB6**: [7:4] YQ1YQ0 (YCC Quantization Range), [3:2] CN1CN0 (Content Type), [1:0] PR3PR0 (Pixel Repetition Factor)
+- **DB7-DB8**: Line number of End of Top Bar (16-bit, LSB first)
+- **DB9-DB10**: Line number of Start of Bottom Bar (16-bit, LSB first)
+- **DB11-DB12**: Pixel number of End of Left Bar (16-bit, LSB first)
+- **DB13-DB14**: Pixel number of Start of Right Bar (16-bit, LSB first)
+
+## 2. Audio Clock Regeneration (ACR) Packet
+Used to synchronize the audio clock at the sink.
+
+- **Packet Type**: 0x01
+- **Version**: 0x00
+- **Length**: 0x00 (Implicitly uses 4 subpackets)
+
+### Header
+- **HB0**: 0x01 (Packet Type)
+- **HB1**: 0x00
+- **HB2**: 0x00
+
+### Subpacket Layout
+All four subpackets (0-3) typically contain the same N and CTS values.
+
+- **Byte 0**: Reserved (0x00)
+- **Byte 1**: [7:4] Reserved, [3:0] CTS [19:16]
+- **Byte 2**: [7:0] CTS [15:8]
+- **Byte 3**: [7:0] CTS [7:0]
+- **Byte 4**: [7:4] Reserved, [3:0] N [19:16]
+- **Byte 5**: [7:0] N [15:8]
+- **Byte 6**: [7:0] N [7:0]
+
+The CTS (Cycle Time Stamp) and N values are used by the sink to regenerate the audio clock ($f_{audio} = f_{pixel} \times \frac{N}{CTS}$).

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -74,6 +74,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_data_island_framer \
     SIM_BUILD=sim_build_hdmi_data_island_framer
 
+echo "--- Running HDMI InfoFrame Checksum Cocotb Test ---"
+rm -rf sim_build_hdmi_checksum
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_infoframe_checksum.v" \
+    TOPLEVEL=hdmi_infoframe_checksum \
+    MODULE=test_hdmi_checksum \
+    SIM_BUILD=sim_build_hdmi_checksum
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_infoframe_checksum.v
+++ b/src/hdmi_infoframe_checksum.v
@@ -1,0 +1,46 @@
+/*
+ * HDMI InfoFrame Checksum Calculator
+ *
+ * Calculates the 8-bit checksum for an HDMI InfoFrame.
+ * The checksum is the 2's complement of the 8-bit sum of all bytes in the
+ * InfoFrame (header + data), where the checksum byte itself is treated as 0.
+ *
+ * This module accepts the 3 header bytes and 4 subpackets (28 data bytes)
+ * and calculates the checksum intended for the first data byte (DB1).
+ */
+
+`default_nettype none
+
+module hdmi_infoframe_checksum (
+    input  wire [7:0]  hb0,
+    input  wire [7:0]  hb1,
+    input  wire [7:0]  hb2,
+    input  wire [55:0] sub0_data, // DB1..DB7 (DB1 is the checksum slot)
+    input  wire [55:0] sub1_data, // DB8..DB14
+    input  wire [55:0] sub2_data, // DB15..DB21
+    input  wire [55:0] sub3_data, // DB22..DB28
+    output wire [7:0]  checksum
+);
+
+    // 8-bit summation will naturally wrap around (modulo 256)
+    wire [7:0] sum_h  = hb0 + hb1 + hb2;
+
+    // We sum DB2 through DB28. DB1 (sub0_data[7:0]) is excluded as it is the checksum slot.
+    wire [7:0] sum_s0 = sub0_data[15:8] + sub0_data[23:16] + sub0_data[31:24] +
+                        sub0_data[39:32] + sub0_data[47:40] + sub0_data[55:48];
+
+    wire [7:0] sum_s1 = sub1_data[7:0]  + sub1_data[15:8]  + sub1_data[23:16] +
+                        sub1_data[31:24] + sub1_data[39:32] + sub1_data[47:40] + sub1_data[55:48];
+
+    wire [7:0] sum_s2 = sub2_data[7:0]  + sub2_data[15:8]  + sub2_data[23:16] +
+                        sub2_data[31:24] + sub2_data[39:32] + sub2_data[47:40] + sub2_data[55:48];
+
+    wire [7:0] sum_s3 = sub3_data[7:0]  + sub3_data[15:8]  + sub3_data[23:16] +
+                        sub3_data[31:24] + sub3_data[39:32] + sub3_data[47:40] + sub3_data[55:48];
+
+    wire [7:0] total_sum = sum_h + sum_s0 + sum_s1 + sum_s2 + sum_s3;
+
+    // Checksum is the 2's complement of the sum
+    assign checksum = -total_sum;
+
+endmodule

--- a/test/test_hdmi_checksum.py
+++ b/test/test_hdmi_checksum.py
@@ -1,0 +1,55 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_hdmi_checksum(dut):
+    """Test HDMI InfoFrame checksum calculation"""
+
+    # Example AVI InfoFrame for 640x480p
+    # HB0 = 0x82, HB1 = 0x02, HB2 = 0x0D
+    # DB1 = Checksum (to be calculated)
+    # DB2 = 0x10 (Scan info)
+    # DB3 = 0x18 (Aspect ratio)
+    # DB4 = 0x00
+    # DB5 = 0x01 (VIC 1)
+    # DB6..DB28 = 0
+
+    dut.hb0.value = 0x82
+    dut.hb1.value = 0x02
+    dut.hb2.value = 0x0D
+
+    # DB1 is at sub0[7:0], we set it to 0 as it shouldn't affect calculation
+    # DB2..DB7 are sub0[15:8]..sub0[55:48]
+    sub0 = 0x00000100181000 # DB7, DB6, DB5, DB4, DB3, DB2, DB1
+    dut.sub0_data.value = sub0
+    dut.sub1_data.value = 0
+    dut.sub2_data.value = 0
+    dut.sub3_data.value = 0
+
+    await Timer(1, unit="ns")
+
+    # Expected sum = 0x82 + 0x02 + 0x0D + 0x10 + 0x18 + 0x00 + 0x01 = 0xC0
+    # Checksum = -0xC0 & 0xFF = 0x40
+
+    expected_sum = (0x82 + 0x02 + 0x0D + 0x10 + 0x18 + 0x00 + 0x01) & 0xFF
+    expected_checksum = (-expected_sum) & 0xFF
+
+    assert dut.checksum.value == expected_checksum, f"Expected {hex(expected_checksum)}, got {hex(int(dut.checksum.value))}"
+
+    # Test with non-zero sub1..sub3
+    dut.sub1_data.value = 0x01020304050607
+    dut.sub2_data.value = 0x08090A0B0C0D0E
+    dut.sub3_data.value = 0x0F101112131415
+
+    await Timer(1, unit="ns")
+
+    sum_h = 0x82 + 0x02 + 0x0D
+    sum_s0 = 0x10 + 0x18 + 0x00 + 0x01 + 0x00 + 0x00 # DB2..DB7
+    sum_s1 = 0x07 + 0x06 + 0x05 + 0x04 + 0x03 + 0x02 + 0x01 # DB8..DB14 (LSB first in sub1_data)
+    sum_s2 = 0x0E + 0x0D + 0x0C + 0x0B + 0x0A + 0x09 + 0x08 # DB15..DB21
+    sum_s3 = 0x15 + 0x14 + 0x13 + 0x12 + 0x11 + 0x10 + 0x0F # DB22..DB28
+
+    total_sum = (sum_h + sum_s0 + sum_s1 + sum_s2 + sum_s3) & 0xFF
+    expected_checksum = (-total_sum) & 0xFF
+
+    assert dut.checksum.value == expected_checksum, f"Expected {hex(expected_checksum)}, got {hex(int(dut.checksum.value))}"


### PR DESCRIPTION
This change researches and documents the byte layouts for HDMI AVI InfoFrames and Audio Clock Regeneration (ACR) packets. It also implements a Verilog module for calculating the 8-bit checksum required for InfoFrames and includes a Cocotb test suite to verify the implementation.

Key changes:
- Created `definitions/hdmi_packets.md` documenting AVI InfoFrame and ACR packet structures.
- Implemented `src/hdmi_infoframe_checksum.v` to calculate the 8-bit 2's complement checksum for HDMI InfoFrames.
- Developed `test/test_hdmi_checksum.py` for automated verification of the checksum logic.
- Integrated the new test into `run_tests.sh`.
- Updated `ROADMAP.md` and `MIGRATION_ROADMAP.md` to mark these goals as completed.

Fixes #75

---
*PR created automatically by Jules for task [10524094912551710074](https://jules.google.com/task/10524094912551710074) started by @chatelao*