### PR TITLE
Implement HDMI AVI InfoFrame generator and refine roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -16,11 +16,11 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## Renode Simulation
 - [x] Correct Renode platform definition (`.repl`) to match CMSDK peripherals.
-- [ ] Implement basic APB register logic in Renode Python model.
-- [ ] Define the Python peripheral class for the Tiny Tapeout APB bridge in Renode.
-- [ ] Implement register read/write logic in the Renode model matching `tt_wrapper.v`.
-- [ ] Integrate a behavioral model of the TT design into the Renode peripheral.
-- [ ] Create a Robot test script to verify M3-to-TT interaction in Renode.
+- [ ] Implement APB register logic in a Python peripheral script for Renode.
+- [ ] Map the Python peripheral to the APB bus at `0x40002400` in `tang_nano_4k.repl`.
+- [ ] Implement register read/write logic in the Python model matching `tt_wrapper.v` (DATA, UIO_DATA, UIO_OE, CTRL).
+- [ ] Integrate a behavioral model of the TT design (e.g., a simple counter or passthrough) into the Renode peripheral.
+- [ ] Create a Robot test script to verify M3-to-TT interaction by reading/writing registers in Renode.
 - [ ] Integrate Renode verification into `run_tests.sh`.
 
 ## APB Expansion & Bridge
@@ -33,7 +33,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 ## HDMI Audio & Data Island Packets
 - [x] Research and document HDMI ACR and InfoFrame byte layouts.
 - [x] Implement InfoFrame Checksum calculation logic.
-- [ ] Implement AVI InfoFrame generator for 640x480p.
+- [x] Implement AVI InfoFrame generator for 640x480p.
 - [ ] Implement Audio Clock Regeneration (ACR) packet generator.
 - [ ] Define Data Island Packet interface and basic arbiter.
 - [ ] Implement scanline-based trigger logic for Data Island packets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,7 @@
 ## Current Goals
 - [x] Research and document HDMI ACR and InfoFrame bit layouts.
 - [x] Implement InfoFrame Checksum calculation logic.
+- [x] Implement AVI InfoFrame generator for 640x480p.
 - [ ] Implement basic APB register logic in Renode Python model.
 - [ ] Define packet interface and basic arbiter for Data Island.
 - [ ] Implement HDMI Audio Clock Regeneration (ACR) packet generation.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -82,6 +82,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_checksum \
     SIM_BUILD=sim_build_hdmi_checksum
 
+echo "--- Running HDMI AVI InfoFrame Cocotb Test ---"
+rm -rf sim_build_hdmi_avi_infoframe
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_avi_infoframe.v $(pwd)/../src/hdmi_infoframe_checksum.v" \
+    TOPLEVEL=hdmi_avi_infoframe \
+    MODULE=test_hdmi_avi_infoframe \
+    SIM_BUILD=sim_build_hdmi_avi_infoframe
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_avi_infoframe.v
+++ b/src/hdmi_avi_infoframe.v
@@ -1,0 +1,55 @@
+/*
+ * HDMI AVI InfoFrame Generator
+ *
+ * Generates an AVI InfoFrame for 640x480p (VIC 1).
+ * Based on CTA-861 and HDMI 1.3a specifications.
+ */
+
+`default_nettype none
+
+module hdmi_avi_infoframe (
+    output wire [23:0] header,
+    output wire [55:0] sub0,
+    output wire [55:0] sub1,
+    output wire [55:0] sub2,
+    output wire [55:0] sub3
+);
+
+    // Header: Type=0x82, Version=0x02, Length=0x0D
+    assign header = {8'h0D, 8'h02, 8'h82};
+
+    // Data Bytes (DB)
+    wire [7:0] db1; // Checksum
+    wire [7:0] db2 = 8'h10; // RGB, Active Format Info = 1, Scan Info = 0
+    wire [7:0] db3 = 8'h18; // Aspect Ratio = 4:3 (1), Active Format Aspect Ratio = 4:3 (8)
+    wire [7:0] db4 = 8'h00; // Standard Colorimetry
+    wire [7:0] db5 = 8'h01; // VIC 1 (640x480p)
+    wire [7:0] db6 = 8'h00;
+    wire [7:0] db7 = 8'h00;
+    wire [7:0] db8 = 8'h00;
+    wire [7:0] db9 = 8'h00;
+    wire [7:0] db10 = 8'h00;
+    wire [7:0] db11 = 8'h00;
+    wire [7:0] db12 = 8'h00;
+    wire [7:0] db13 = 8'h00;
+    wire [7:0] db14 = 8'h00;
+
+    // Checksum calculation
+    hdmi_infoframe_checksum checksum_inst (
+        .hb0(header[7:0]),
+        .hb1(header[15:8]),
+        .hb2(header[23:16]),
+        .sub0_data({db7, db6, db5, db4, db3, db2, 8'h00}), // DB1 slot is 0 for sum
+        .sub1_data({db14, db13, db12, db11, db10, db9, db8}),
+        .sub2_data(56'h0),
+        .sub3_data(56'h0),
+        .checksum(db1)
+    );
+
+    // Packing into subpackets
+    assign sub0 = {db7, db6, db5, db4, db3, db2, db1};
+    assign sub1 = {db14, db13, db12, db11, db10, db9, db8};
+    assign sub2 = 56'h0;
+    assign sub3 = 56'h0;
+
+endmodule

--- a/test/test_hdmi_avi_infoframe.py
+++ b/test/test_hdmi_avi_infoframe.py
@@ -1,0 +1,35 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_hdmi_avi_infoframe(dut):
+    """Test HDMI AVI InfoFrame generator for 640x480p"""
+
+    await Timer(1, unit="ns")
+
+    # Header: Type=0x82, Version=0x02, Length=0x0D
+    # Header is {8'h0D, 8'h02, 8'h82}
+    header = int(dut.header.value)
+    assert header == 0x0D0282, f"Expected header 0x0D0282, got {hex(header)}"
+
+    # Subpacket 0: {db7, db6, db5, db4, db3, db2, db1}
+    # db1 = Checksum
+    # db2 = 0x10, db3 = 0x18, db4 = 0x00, db5 = 0x01, db6 = 0x00, db7 = 0x00
+    # Expected sum = 0x82 + 0x02 + 0x0D + 0x10 + 0x18 + 0x00 + 0x01 = 0xBA
+    # Checksum (db1) = -0xBA & 0xFF = 0x46
+    # sub0 = {0x00, 0x00, 0x01, 0x00, 0x18, 0x10, 0x46} = 0x00000100181046
+
+    sub0 = int(dut.sub0.value)
+    expected_sub0 = 0x00000100181046
+    assert sub0 == expected_sub0, f"Expected sub0 {hex(expected_sub0)}, got {hex(sub0)}"
+
+    sub1 = int(dut.sub1.value)
+    assert sub1 == 0, f"Expected sub1 0, got {hex(sub1)}"
+
+    sub2 = int(dut.sub2.value)
+    assert sub2 == 0, f"Expected sub2 0, got {hex(sub2)}"
+
+    sub3 = int(dut.sub3.value)
+    assert sub3 == 0, f"Expected sub3 0, got {hex(sub3)}"
+
+    dut._log.info("HDMI AVI InfoFrame generator test passed")


### PR DESCRIPTION
This PR implements the HDMI AVI InfoFrame generator for 640x480p (VIC 1) resolution, which is essential for notifying the sink about the video format. It also includes a Cocotb test bench to verify the correct generation of header and subpacket data, including the checksum. Furthermore, the roadmap documents have been updated to reflect this progress and to break down the upcoming Renode simulation work into smaller, more manageable sub-tasks.

Fixes #77

---
*PR created automatically by Jules for task [15754202318885589026](https://jules.google.com/task/15754202318885589026) started by @chatelao*