### PR TITLE
Implement HDMI ACR Packet Generation

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -34,7 +34,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Research and document HDMI ACR and InfoFrame byte layouts.
 - [x] Implement InfoFrame Checksum calculation logic.
 - [x] Implement AVI InfoFrame generator for 640x480p.
-- [ ] Implement Audio Clock Regeneration (ACR) packet generator.
+- [x] Implement Audio Clock Regeneration (ACR) packet generator.
 - [ ] Define Data Island Packet interface and basic arbiter.
 - [ ] Implement scanline-based trigger logic for Data Island packets.
 - [ ] Multiplex AVI InfoFrame and ACR packets in the scheduler.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@
 - [x] Implement AVI InfoFrame generator for 640x480p.
 - [ ] Implement basic APB register logic in Renode Python model.
 - [ ] Define packet interface and basic arbiter for Data Island.
-- [ ] Implement HDMI Audio Clock Regeneration (ACR) packet generation.
+- [ ] Implement 1-bit PWM audio generator for 48kHz sampling.
 
 ## Completed
+- [x] Implement HDMI Audio Clock Regeneration (ACR) packet generation.
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
 - [x] Implement HDMI Packet Packer (ECC calculation and bit mapping).
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -90,6 +90,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_avi_infoframe \
     SIM_BUILD=sim_build_hdmi_avi_infoframe
 
+echo "--- Running HDMI ACR Packet Cocotb Test ---"
+rm -rf sim_build_hdmi_acr_packet
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_acr_packet.v" \
+    TOPLEVEL=hdmi_acr_packet \
+    MODULE=test_hdmi_acr_packet \
+    SIM_BUILD=sim_build_hdmi_acr_packet
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_acr_packet.v
+++ b/src/hdmi_acr_packet.v
@@ -1,0 +1,48 @@
+/*
+ * HDMI Audio Clock Regeneration (ACR) Packet Generator
+ *
+ * Generates an ACR packet containing CTS and N values.
+ * Based on HDMI 1.3a Section 5.3.3 and Table 5-10.
+ */
+
+`default_nettype none
+
+module hdmi_acr_packet (
+    input  wire [19:0] cts,
+    input  wire [19:0] n,
+    output wire [23:0] header,
+    output wire [55:0] sub0,
+    output wire [55:0] sub1,
+    output wire [55:0] sub2,
+    output wire [55:0] sub3
+);
+
+    // Header: HB0=0x01 (Packet Type), HB1=0x00, HB2=0x00
+    assign header = {8'h00, 8'h00, 8'h01};
+
+    // Subpacket layout (HDMI 1.3a Table 5-10):
+    // Byte 0: 0x00
+    // Byte 1: [7:4] Reserved (0), [3:0] CTS [19:16]
+    // Byte 2: [7:0] CTS [15:8]
+    // Byte 3: [7:0] CTS [7:0]
+    // Byte 4: [7:4] Reserved (0), [3:0] N [19:16]
+    // Byte 5: [7:0] N [15:8]
+    // Byte 6: [7:0] N [7:0]
+
+    wire [55:0] acr_subpacket = {
+        n[7:0],           // Byte 6
+        n[15:8],          // Byte 5
+        4'b0, n[19:16],   // Byte 4
+        cts[7:0],         // Byte 3
+        cts[15:8],        // Byte 2
+        4'b0, cts[19:16], // Byte 1
+        8'h00             // Byte 0
+    };
+
+    // All four subpackets are identical for ACR
+    assign sub0 = acr_subpacket;
+    assign sub1 = acr_subpacket;
+    assign sub2 = acr_subpacket;
+    assign sub3 = acr_subpacket;
+
+endmodule

--- a/test/test_hdmi_acr_packet.py
+++ b/test/test_hdmi_acr_packet.py
@@ -1,0 +1,47 @@
+import cocotb
+from cocotb.triggers import Timer
+
+@cocotb.test()
+async def test_hdmi_acr_packet(dut):
+    """Test HDMI ACR Packet generator"""
+
+    # Example values for 48kHz audio with 25.2MHz pixel clock
+    # Reference: HDMI 1.3a Table 7-1
+    # For 25.2MHz pixel clock: N=6144, CTS=25200
+    n_val = 6144
+    cts_val = 25200
+
+    dut.n.value = n_val
+    dut.cts.value = cts_val
+
+    await Timer(1, unit="ns")
+
+    # Header: Type=0x01, HB1=0x00, HB2=0x00 -> 0x000001
+    header = int(dut.header.value)
+    assert header == 0x000001, f"Expected header 0x000001, got {hex(header)}"
+
+    # Subpacket 0-3 should be identical
+    expected_sub = (n_val & 0xFF) << 48 | \
+                   ((n_val >> 8) & 0xFF) << 40 | \
+                   ((n_val >> 16) & 0x0F) << 32 | \
+                   (cts_val & 0xFF) << 24 | \
+                   ((cts_val >> 8) & 0xFF) << 16 | \
+                   ((cts_val >> 16) & 0x0F) << 8 | \
+                   0x00
+
+    # manual calculation for 6144 (0x1800), 25200 (0x6270):
+    # n[7:0] = 0x00
+    # n[15:8] = 0x18
+    # n[19:16] = 0x0
+    # cts[7:0] = 0x70
+    # cts[15:8] = 0x62
+    # cts[19:16] = 0x0
+    # sub = {0x00, 0x18, 0x00, 0x70, 0x62, 0x00, 0x00}
+    # sub = 0x00180070620000
+
+    assert int(dut.sub0.value) == expected_sub, f"Expected sub0 {hex(expected_sub)}, got {hex(int(dut.sub0.value))}"
+    assert int(dut.sub1.value) == expected_sub, f"Expected sub1 {hex(expected_sub)}, got {hex(int(dut.sub1.value))}"
+    assert int(dut.sub2.value) == expected_sub, f"Expected sub2 {hex(expected_sub)}, got {hex(int(dut.sub2.value))}"
+    assert int(dut.sub3.value) == expected_sub, f"Expected sub3 {hex(expected_sub)}, got {hex(int(dut.sub3.value))}"
+
+    dut._log.info("HDMI ACR packet generator test passed")


### PR DESCRIPTION
This PR implements the HDMI Audio Clock Regeneration (ACR) packet generator, a key component for audio synchronization in the HDMI subsystem. The module correctly packs 20-bit CTS and N values into the specification-defined header and subpackets. Verification is provided via a new Cocotb test bench integrated into the existing automated test suite. Roadmaps have been updated to reflect this milestone and define subsequent tasks such as PWM audio generation and packet arbitration.

Fixes #79

---
*PR created automatically by Jules for task [10182088441133483532](https://jules.google.com/task/10182088441133483532) started by @chatelao*