### PR TITLE
Implement HDMI Data Island Scheduler

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -35,9 +35,9 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Implement InfoFrame Checksum calculation logic.
 - [x] Implement AVI InfoFrame generator for 640x480p.
 - [x] Implement Audio Clock Regeneration (ACR) packet generator.
-- [ ] Define Data Island Packet interface and basic arbiter.
-- [ ] Implement scanline-based trigger logic for Data Island packets.
-- [ ] Multiplex AVI InfoFrame and ACR packets in the scheduler.
+- [x] Define Data Island Packet interface and basic arbiter.
+- [x] Implement scanline-based trigger logic for Data Island packets.
+- [x] Multiplex AVI InfoFrame and ACR packets in the scheduler.
 - [ ] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@
 - [x] Research and document HDMI ACR and InfoFrame bit layouts.
 - [x] Implement InfoFrame Checksum calculation logic.
 - [x] Implement AVI InfoFrame generator for 640x480p.
+- [x] Implement HDMI Data Island Scheduler (Interface, Arbiter, and Trigger logic).
 - [ ] Implement basic APB register logic in Renode Python model.
-- [ ] Define packet interface and basic arbiter for Data Island.
 - [ ] Implement 1-bit PWM audio generator for 48kHz sampling.
 
 ## Completed

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -98,6 +98,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_acr_packet \
     SIM_BUILD=sim_build_hdmi_acr_packet
 
+echo "--- Running HDMI Scheduler Cocotb Test ---"
+rm -rf sim_build_hdmi_scheduler
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/hdmi_data_island_scheduler.v $(pwd)/../src/hdmi_avi_infoframe.v $(pwd)/../src/hdmi_acr_packet.v $(pwd)/../src/hdmi_infoframe_checksum.v" \
+    TOPLEVEL=hdmi_data_island_scheduler \
+    MODULE=test_hdmi_scheduler \
+    SIM_BUILD=sim_build_hdmi_scheduler
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/hdmi_data_island_scheduler.v
+++ b/src/hdmi_data_island_scheduler.v
@@ -1,0 +1,102 @@
+/*
+ * HDMI Data Island Scheduler
+ *
+ * Manages the timing and multiplexing of Data Island packets.
+ * Triggers AVI InfoFrames once per frame and ACR packets periodically.
+ */
+
+`default_nettype none
+
+module hdmi_data_island_scheduler (
+    input  wire        clk,
+    input  wire        reset,
+    input  wire        vde,
+    input  wire        hsync,
+    input  wire        vsync,
+    // Data Island Interface to hdmi_tx
+    output reg         di_start,
+    output reg  [23:0] di_header,
+    output reg  [55:0] di_sub0,
+    output reg  [55:0] di_sub1,
+    output reg  [55:0] di_sub2,
+    output reg  [55:0] di_sub3,
+    input  wire        di_active
+);
+
+    // Packet Generators
+    wire [23:0] avi_header;
+    wire [55:0] avi_sub0, avi_sub1, avi_sub2, avi_sub3;
+    hdmi_avi_infoframe avi_gen (
+        .header(avi_header),
+        .sub0(avi_sub0),
+        .sub1(avi_sub1),
+        .sub2(avi_sub2),
+        .sub3(avi_sub3)
+    );
+
+    wire [23:0] acr_header;
+    wire [55:0] acr_sub0, acr_sub1, acr_sub2, acr_sub3;
+    // For 25.2MHz pixel clock and 48kHz audio:
+    // N = 6144, CTS = 25200 (exact)
+    hdmi_acr_packet acr_gen (
+        .cts(20'd25200),
+        .n(20'd6144),
+        .header(acr_header),
+        .sub0(acr_sub0),
+        .sub1(acr_sub1),
+        .sub2(acr_sub2),
+        .sub3(acr_sub3)
+    );
+
+    // Trigger Logic
+    reg vsync_prev;
+    reg avi_pending;
+    reg hsync_prev;
+
+    always @(posedge clk) begin
+        if (reset) begin
+            vsync_prev <= 1'b1;
+            hsync_prev <= 1'b1;
+            avi_pending <= 1'b0;
+            di_start <= 1'b0;
+            di_header <= 24'b0;
+            di_sub0 <= 56'b0;
+            di_sub1 <= 56'b0;
+            di_sub2 <= 56'b0;
+            di_sub3 <= 56'b0;
+        end else begin
+            vsync_prev <= vsync;
+            hsync_prev <= hsync;
+
+            // Trigger AVI InfoFrame on falling edge of vsync
+            if (vsync_prev && !vsync) begin
+                avi_pending <= 1'b1;
+            end
+
+            // Data Island Transmission State Machine
+            if (!di_active && !di_start) begin
+                if (avi_pending && !vde) begin
+                    // Send AVI InfoFrame during blanking
+                    di_start <= 1'b1;
+                    di_header <= avi_header;
+                    di_sub0 <= avi_sub0;
+                    di_sub1 <= avi_sub1;
+                    di_sub2 <= avi_sub2;
+                    di_sub3 <= avi_sub3;
+                    avi_pending <= 1'b0;
+                end else if (!vde && hsync_prev && !hsync) begin
+                    // Send ACR packet at the start of every horizontal sync period
+                    di_start <= 1'b1;
+                    di_header <= acr_header;
+                    di_sub0 <= acr_sub0;
+                    di_sub1 <= acr_sub1;
+                    di_sub2 <= acr_sub2;
+                    di_sub3 <= acr_sub3;
+                end
+            end else begin
+                di_start <= 1'b0;
+            end
+        end
+    end
+
+endmodule

--- a/src/top.v
+++ b/src/top.v
@@ -62,6 +62,27 @@ module top (
     wire [7:0] vga_g = {tt_uo_out[1], tt_uo_out[5], 6'b0};
     wire [7:0] vga_b = {tt_uo_out[2], tt_uo_out[6], 6'b0};
 
+    // --- HDMI Data Island Scheduler ---
+    wire        di_start;
+    wire [23:0] di_header;
+    wire [55:0] di_sub0, di_sub1, di_sub2, di_sub3;
+    wire        di_active;
+
+    hdmi_data_island_scheduler di_scheduler_inst (
+        .clk(clk_pixel),
+        .reset(~pll_lock),
+        .vde(vga_vde),
+        .hsync(vga_hsync),
+        .vsync(vga_vsync),
+        .di_start(di_start),
+        .di_header(di_header),
+        .di_sub0(di_sub0),
+        .di_sub1(di_sub1),
+        .di_sub2(di_sub2),
+        .di_sub3(di_sub3),
+        .di_active(di_active)
+    );
+
     // --- HDMI Transmitter ---
     hdmi_tx hdmi_tx_inst (
         .clk_pixel(clk_pixel),
@@ -73,13 +94,13 @@ module top (
         .hsync(vga_hsync),
         .vsync(vga_vsync),
         .vde(vga_vde),
-        .di_start(1'b0),
-        .di_header(24'b0),
-        .di_sub0(56'b0),
-        .di_sub1(56'b0),
-        .di_sub2(56'b0),
-        .di_sub3(56'b0),
-        .di_active(),
+        .di_start(di_start),
+        .di_header(di_header),
+        .di_sub0(di_sub0),
+        .di_sub1(di_sub1),
+        .di_sub2(di_sub2),
+        .di_sub3(di_sub3),
+        .di_active(di_active),
         .ser_clk(tmds_clk_p),
         .ser_d0(tmds_d_p[0]),
         .ser_d1(tmds_d_p[1]),

--- a/test/test_hdmi_scheduler.py
+++ b/test/test_hdmi_scheduler.py
@@ -1,0 +1,84 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer, FallingEdge
+
+@cocotb.test()
+async def test_hdmi_scheduler_triggers(dut):
+    """Test that the scheduler triggers AVI and ACR packets at correct times"""
+    clock = Clock(dut.clk, 40, unit="ns")  # 25MHz approx
+    cocotb.start_soon(clock.start())
+
+    dut.reset.value = 1
+    dut.vde.value = 0
+    dut.hsync.value = 1
+    dut.vsync.value = 1
+    dut.di_active.value = 0
+    await Timer(100, unit="ns")
+    dut.reset.value = 0
+    await RisingEdge(dut.clk)
+
+    # Test AVI trigger on VSync falling edge
+    dut.vsync.value = 0
+    await RisingEdge(dut.clk) # avi_pending becomes 1
+    await RisingEdge(dut.clk) # di_start becomes 1
+    await Timer(1, unit="ns")
+    assert dut.di_start.value == 1, "AVI should trigger after VSync falling edge"
+    assert int(dut.di_header.value) == 0x0D0282, "Header should be AVI InfoFrame"
+
+    # Simulate di_active from framer
+    dut.di_active.value = 1
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    assert dut.di_start.value == 0, "di_start should drop once active"
+
+    # Finish packet
+    dut.di_active.value = 0
+    await RisingEdge(dut.clk)
+
+    # Test ACR trigger on HSync falling edge
+    dut.hsync.value = 0
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    assert dut.di_start.value == 1, "ACR should trigger on HSync falling edge during blanking"
+    assert int(dut.di_header.value) == 0x000001, "Header should be ACR packet"
+
+    dut.di_active.value = 1
+    await RisingEdge(dut.clk)
+    dut.di_active.value = 0
+    await RisingEdge(dut.clk)
+
+    # Test that triggers don't happen during VDE
+    dut.vde.value = 1
+    dut.hsync.value = 1
+    await RisingEdge(dut.clk)
+    dut.hsync.value = 0
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    assert dut.di_start.value == 0, "Triggers should be suppressed during VDE"
+
+@cocotb.test()
+async def test_hdmi_scheduler_prioritization(dut):
+    """Test that AVI has priority over ACR if both pending"""
+    clock = Clock(dut.clk, 40, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.reset.value = 1
+    dut.vde.value = 0
+    dut.hsync.value = 1
+    dut.vsync.value = 1
+    dut.di_active.value = 0
+    await Timer(100, unit="ns")
+    dut.reset.value = 0
+    await RisingEdge(dut.clk)
+
+    # Trigger AVI pending
+    dut.vsync.value = 0
+    # But keep HSync high for now
+    await RisingEdge(dut.clk)
+
+    # Now trigger HSync low (both AVI pending and HSync trigger active)
+    dut.hsync.value = 0
+    await RisingEdge(dut.clk)
+    await Timer(1, unit="ns")
+    assert dut.di_start.value == 1
+    assert int(dut.di_header.value) == 0x0D0282, "AVI should have priority over ACR"


### PR DESCRIPTION
Implemented the HDMI Data Island Scheduler to manage AVI InfoFrame and ACR packet transmission. Integrated the scheduler into the top-level design and added comprehensive Cocotb tests.

Fixes #81

---
*PR created automatically by Jules for task [5715296473391450168](https://jules.google.com/task/5715296473391450168) started by @chatelao*