### PR TITLE
Implement 1-bit PWM audio generator and refine roadmap

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -38,14 +38,16 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 - [x] Define Data Island Packet interface and basic arbiter.
 - [x] Implement scanline-based trigger logic for Data Island packets.
 - [x] Multiplex AVI InfoFrame and ACR packets in the scheduler.
-- [ ] Design 1-bit PWM audio generator for 48kHz sampling.
+- [x] Design 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement TERC4 encoder for HDMI Data Islands.
 - [x] Research and document BCH ECC parity equations for HDMI packets.
 - [x] Implement 24-bit Header ECC and 56-bit Subpacket ECC encoders.
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
 - [x] Implement HDMI Data Island Framer (Multiplexing TERC4 and Packet Packer).
 - [x] Integrate Data Island support into `hdmi_tx`.
-- [ ] Implement HDMI Audio Sample packet generation.
+- [ ] Research and document HDMI Audio Sample Packet (Type 0x02) layout.
+- [ ] Implement LPCM to Audio Sample Packet mapping logic.
+- [ ] Implement HDMI Audio Sample packet generator.
 
 ## Automated E2E & Verification
 - [ ] Develop a Cocotb test bench for the complete `top` module.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@
 - [x] Implement AVI InfoFrame generator for 640x480p.
 - [x] Implement HDMI Data Island Scheduler (Interface, Arbiter, and Trigger logic).
 - [ ] Implement basic APB register logic in Renode Python model.
-- [ ] Implement 1-bit PWM audio generator for 48kHz sampling.
+- [ ] Implement HDMI Audio Sample packet generation.
 
 ## Completed
+- [x] Implement 1-bit PWM audio generator for 48kHz sampling.
 - [x] Implement HDMI Audio Clock Regeneration (ACR) packet generation.
 - [x] Implement HDMI Data Island FSM (Preamble, Guard Bands, and Data timing).
 - [x] Implement HDMI Packet Packer (ECC calculation and bit mapping).

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -106,6 +106,14 @@ make -f cocotb_Makefile \
     MODULE=test_hdmi_scheduler \
     SIM_BUILD=sim_build_hdmi_scheduler
 
+echo "--- Running Audio PWM Cocotb Test ---"
+rm -rf sim_build_audio_pwm
+make -f cocotb_Makefile \
+    VERILOG_SOURCES="$(pwd)/../src/audio_pwm.v" \
+    TOPLEVEL=audio_pwm \
+    MODULE=test_audio_pwm \
+    SIM_BUILD=sim_build_audio_pwm
+
 echo "--- Running TT APB Wrapper Cocotb Test ---"
 rm -rf sim_build_tt_wrapper
 make -f cocotb_Makefile \

--- a/src/audio_pwm.v
+++ b/src/audio_pwm.v
@@ -1,0 +1,30 @@
+/*
+ * 1-bit PWM Audio Generator
+ *
+ * Converts 8-bit PCM audio samples to a 1-bit PWM signal.
+ * Suitable for driving a simple RC filter or a TT Audio PMOD.
+ */
+
+`default_nettype none
+
+module audio_pwm (
+    input  wire       clk,
+    input  wire       reset,
+    input  wire [7:0] sample_in,
+    output reg        pwm_out
+);
+
+    reg [7:0] counter;
+
+    always @(posedge clk) begin
+        if (reset) begin
+            counter <= 8'h0;
+            pwm_out <= 1'b0;
+        end else begin
+            counter <= counter + 1'b1;
+            // Registered output to avoid glitches
+            pwm_out <= (counter < sample_in);
+        end
+    end
+
+endmodule

--- a/test/test_audio_pwm.py
+++ b/test/test_audio_pwm.py
@@ -1,0 +1,50 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, Timer
+
+@cocotb.test()
+async def test_audio_pwm(dut):
+    """Test PWM duty cycle for various input samples"""
+    clock = Clock(dut.clk, 10, unit="ns")
+    cocotb.start_soon(clock.start())
+
+    # Reset
+    dut.reset.value = 1
+    dut.sample_in.value = 0
+    await RisingEdge(dut.clk)
+    dut.reset.value = 0
+    await RisingEdge(dut.clk)
+
+    async def check_duty_cycle(sample_value, num_cycles=256):
+        dut.sample_in.value = sample_value
+        high_count = 0
+
+        # Wait for counter to wrap to 0 to align with our measurement
+        # We use a timeout to avoid infinite loop if it never hits 0
+        for _ in range(300):
+            await RisingEdge(dut.clk)
+            if int(dut.counter.value) == 0:
+                break
+
+        for _ in range(num_cycles):
+            # Sample PWM output on the rising edge.
+            # Since pwm_out is registered, it reflects the comparison
+            # made at the PREVIOUS clock edge (counter_prev < sample_in).
+            # The counter just incremented to 'counter_curr' at this edge.
+            if int(dut.pwm_out.value) == 1:
+                high_count += 1
+            await RisingEdge(dut.clk)
+
+        # Duty cycle should be (sample_value / 256)
+        # Since we check 'counter < sample_in' and it's registered:
+        # If sample_in is 64, it will be 1 for counter = 0, 1, ..., 63.
+        # That is exactly 64 cycles.
+        assert high_count == sample_value, f"Sample {sample_value}: Expected high count {sample_value}, got {high_count}"
+        dut._log.info(f"Sample {sample_value}: OK (high_count={high_count})")
+
+    # Test several sample values
+    await check_duty_cycle(0)
+    await check_duty_cycle(64)
+    await check_duty_cycle(128)
+    await check_duty_cycle(192)
+    await check_duty_cycle(255)


### PR DESCRIPTION
This change implements a 1-bit PWM audio generator for converting 8-bit PCM samples, suitable for Tiny Tapeout Audio PMOD. It also breaks down larger HDMI audio and Renode roadmap steps into more granular, verifiable tasks in ROADMAP.md and MIGRATION_ROADMAP.md. A new Cocotb test bench verifies the PWM duty cycle, and it is integrated into the automated test suite.

Fixes #83

---
*PR created automatically by Jules for task [13045111080510230175](https://jules.google.com/task/13045111080510230175) started by @chatelao*