### PR TITLE
Refine Roadmap with Granular Development Steps

### DIFF
--- a/MIGRATION_ROADMAP.md
+++ b/MIGRATION_ROADMAP.md
@@ -16,6 +16,7 @@ This document breaks down the high-level goals in `ROADMAP.md` into modest, feas
 
 ## Renode Simulation
 - [x] Correct Renode platform definition (`.repl`) to match CMSDK peripherals.
+- [ ] Create a minimal Python peripheral template for Renode that can be loaded in `tang_nano_4k.resc`.
 - [ ] Implement APB register logic in a Python peripheral script for Renode.
 - [ ] Map the Python peripheral to the APB bus at `0x40002400` in `tang_nano_4k.repl`.
 - [ ] Implement register read/write logic in the Python model matching `tt_wrapper.v` (DATA, UIO_DATA, UIO_OE, CTRL).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,8 @@
 - [x] Implement InfoFrame Checksum calculation logic.
 - [x] Implement AVI InfoFrame generator for 640x480p.
 - [x] Implement HDMI Data Island Scheduler (Interface, Arbiter, and Trigger logic).
+- [ ] Create a minimal Python peripheral template for Renode.
+- [ ] Research and document HDMI Audio Sample Packet (Type 0x02) layout.
 - [ ] Implement basic APB register logic in Renode Python model.
 - [ ] Implement HDMI Audio Sample packet generation.
 


### PR DESCRIPTION
This change refines the project roadmaps by breaking down large, complex goals into smaller, more manageable tasks. Specifically, it introduces a research and documentation phase for the HDMI Audio Sample Packet (Type 0x02) and adds a preliminary step for Renode simulation by proposing the creation of a minimal Python peripheral template. These updates provide a clearer and more incremental path for future development.

Fixes #85

---
*PR created automatically by Jules for task [17646483979716455471](https://jules.google.com/task/17646483979716455471) started by @chatelao*