### PR TITLE
Add VGA and Audio example project

### DIFF
--- a/examples/tt_projects/vga_audio/README.md
+++ b/examples/tt_projects/vga_audio/README.md
@@ -5,7 +5,7 @@ This example demonstrates generating both VGA video and square wave audio on a T
 ## Features
 
 - **640x480 VGA Output**: Generates standard VGA timing signals and a simple color bar pattern.
-- **Controlled Audio**: Generates a square wave audio signal. The frequency of the signal is adjustable using the `ui_in` inputs.
+- **Controlled Audio**: Generates a square wave audio signal. The frequency of the signal changes automatically over time (sweep) and can be further offset using the `ui_in` inputs.
 - **HDMI Compatibility**: Includes a Video Data Enable (VDE) signal on `uio_out[0]`, making it compatible with the project's HDMI transmitter integration.
 
 ## Pinout
@@ -25,4 +25,4 @@ This example demonstrates generating both VGA video and square wave audio on a T
 - `uio_out[0]`: Video Data Enable (VDE)
 
 ### Inputs (`ui_in`)
-- `ui_in[7:0]`: Controls the audio frequency (period is proportional to the input value).
+- `ui_in[7:0]`: Provides a frequency offset for the automatic audio sweep.

--- a/examples/tt_projects/vga_audio/README.md
+++ b/examples/tt_projects/vga_audio/README.md
@@ -1,0 +1,28 @@
+# VGA and Audio Example
+
+This example demonstrates generating both VGA video and square wave audio on a Tiny Tapeout chip.
+
+## Features
+
+- **640x480 VGA Output**: Generates standard VGA timing signals and a simple color bar pattern.
+- **Controlled Audio**: Generates a square wave audio signal. The frequency of the signal is adjustable using the `ui_in` inputs.
+- **HDMI Compatibility**: Includes a Video Data Enable (VDE) signal on `uio_out[0]`, making it compatible with the project's HDMI transmitter integration.
+
+## Pinout
+
+### Outputs (`uo_out`) - TinyVGA PMOD
+- `uo_out[7]`: HSync
+- `uo_out[6]`: Blue 0
+- `uo_out[5]`: Green 0
+- `uo_out[4]`: Red 0
+- `uo_out[3]`: VSync
+- `uo_out[2]`: Blue 1
+- `uo_out[1]`: Green 1
+- `uo_out[0]`: Red 1
+
+### Bidirectional IOs (`uio_out`)
+- `uio_out[7]`: Audio Square Wave
+- `uio_out[0]`: Video Data Enable (VDE)
+
+### Inputs (`ui_in`)
+- `ui_in[7:0]`: Controls the audio frequency (period is proportional to the input value).

--- a/examples/tt_projects/vga_audio/project.v
+++ b/examples/tt_projects/vga_audio/project.v
@@ -1,0 +1,88 @@
+/*
+ * VGA and Audio Example for Tiny Tapeout
+ *
+ * This project generates a simple VGA pattern and a square wave audio signal.
+ * The audio frequency can be controlled using the dedicated inputs (ui_in).
+ *
+ * Copyright (c) 2024 Jules
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
+module tt_um_vga_audio(
+  input  wire [7:0] ui_in,    // Dedicated inputs
+  output wire [7:0] uo_out,   // Dedicated outputs
+  input  wire [7:0] uio_in,   // IOs: Input path
+  output wire [7:0] uio_out,  // IOs: Output path
+  output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+  input  wire       ena,      // always 1 when the design is powered, so you can ignore it
+  input  wire       clk,      // clock
+  input  wire       rst_n     // reset_n - low to reset
+);
+
+  // VGA counter logic
+  reg [9:0] h_count;
+  reg [9:0] v_count;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      h_count <= 0;
+      v_count <= 0;
+    end else begin
+      if (h_count == 799) begin
+        h_count <= 0;
+        if (v_count == 524)
+          v_count <= 0;
+        else
+          v_count <= v_count + 1;
+      end else begin
+        h_count <= h_count + 1;
+      end
+    end
+  end
+
+  // VGA sync and active signals
+  wire hsync = ~(h_count >= 656 && h_count < 752);
+  wire vsync = ~(v_count >= 490 && v_count < 492);
+  wire video_active = (h_count < 640 && v_count < 480);
+
+  // Simple color pattern
+  wire [1:0] R = video_active ? {h_count[7], h_count[6]} : 2'b00;
+  wire [1:0] G = video_active ? {v_count[7], v_count[6]} : 2'b00;
+  wire [1:0] B = video_active ? {h_count[8], v_count[8]} : 2'b00;
+
+  // TinyVGA PMOD: {hsync, B0, G0, R0, vsync, B1, G1, R1}
+  assign uo_out = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
+
+  // Audio generation: Square wave
+  reg [16:0] audio_counter;
+  reg audio_out;
+  // Use ui_in to control frequency.
+  // Period is (ui_in << 8) + 2048 cycles.
+  // Period is now 17 bits to avoid overflow (max 0xFF00 + 0x0800 = 0x10700).
+  wire [16:0] audio_period = {1'b0, ui_in, 8'h00} + 17'h00800;
+
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      audio_counter <= 0;
+      audio_out <= 0;
+    end else begin
+      if (audio_counter >= audio_period) begin
+        audio_counter <= 0;
+        audio_out <= ~audio_out;
+      end else begin
+        audio_counter <= audio_counter + 1'b1;
+      end
+    end
+  end
+
+  // uio_out[7]: Audio signal
+  // uio_out[0]: Video Data Enable (VDE) for HDMI compatibility
+  assign uio_out = {audio_out, 6'b0, video_active};
+  assign uio_oe  = 8'h81; // uio_out[7] and uio_out[0] as outputs
+
+  // Suppress unused signals warning
+  wire _unused = &{uio_in, ena};
+
+endmodule

--- a/examples/tt_projects/vga_audio/project.v
+++ b/examples/tt_projects/vga_audio/project.v
@@ -2,7 +2,8 @@
  * VGA and Audio Example for Tiny Tapeout
  *
  * This project generates a simple VGA pattern and a square wave audio signal.
- * The audio frequency can be controlled using the dedicated inputs (ui_in).
+ * The audio frequency changes automatically over time and can be further
+ * offset using the dedicated inputs (ui_in).
  *
  * Copyright (c) 2024 Jules
  * SPDX-License-Identifier: Apache-2.0
@@ -55,13 +56,23 @@ module tt_um_vga_audio(
   // TinyVGA PMOD: {hsync, B0, G0, R0, vsync, B1, G1, R1}
   assign uo_out = {hsync, B[0], G[0], R[0], vsync, B[1], G[1], R[1]};
 
+  // Automatic frequency sweep logic
+  reg [7:0] sweep_counter;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      sweep_counter <= 0;
+    end else if (h_count == 0 && v_count == 0) begin
+      sweep_counter <= sweep_counter + 1'b1;
+    end
+  end
+
   // Audio generation: Square wave
   reg [16:0] audio_counter;
   reg audio_out;
-  // Use ui_in to control frequency.
-  // Period is (ui_in << 8) + 2048 cycles.
-  // Period is now 17 bits to avoid overflow (max 0xFF00 + 0x0800 = 0x10700).
-  wire [16:0] audio_period = {1'b0, ui_in, 8'h00} + 17'h00800;
+  // Use ui_in and sweep_counter to control frequency.
+  wire [7:0] combined_freq = ui_in + sweep_counter;
+  // Period is (combined_freq << 8) + 2048 cycles.
+  wire [16:0] audio_period = {1'b0, combined_freq, 8'h00} + 17'h00800;
 
   always @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin


### PR DESCRIPTION
This PR adds a new example project to `examples/tt_projects` that demonstrates both VGA video and audio generation. 

The `vga_audio` project features:
- Standard 640x480 VGA timing.
- A simple color bar pattern.
- A square wave audio generator whose frequency is controlled via the `ui_in` inputs.
- Audio output on `uio_out[7]` and Video Data Enable (VDE) on `uio_out[0]`.

The implementation follows Tiny Tapeout best practices, including asynchronous resets and overflow-safe counter widths.

Fixes #87

---
*PR created automatically by Jules for task [4216446991338109795](https://jules.google.com/task/4216446991338109795) started by @chatelao*