### PR TITLE
Add Verilog linting to CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install Toolchain
         run: bash install.sh
 
+      - name: Lint Verilog
+        run: bash scripts/lint.sh
+
       - name: Run Tests
         run: bash run_tests.sh
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ echo "Installing Toolchain for VGA-to-HDMI Project..."
 sudo apt-get update
 
 # Install FPGA Tools
-echo "Installing FPGA Tools (Yosys, Nextpnr-Gowin, Iverilog)..."
-sudo apt-get install -y yosys nextpnr-gowin iverilog
+echo "Installing FPGA Tools (Yosys, Nextpnr-Gowin, Iverilog, Verilator)..."
+sudo apt-get install -y yosys nextpnr-gowin iverilog verilator
 
 # Install ARM Cross-Compiler
 echo "Installing ARM Cross-Compiler..."

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Verilog Linting Script using Verilator
+
+set -e
+
+echo "Running Verilog linting..."
+
+# Run Verilator linting
+# - -lint-only: Perform linting without generating code
+# - -Isrc: Include source directory for header files
+# - src/top.v: Top-level source file
+# - test/lint_stubs.v: Stubs for external/primitive modules
+# - --top-module top: Specify the top-level module
+# - -Wall: Enable all warnings (optional, adjust as needed)
+
+verilator --lint-only -Isrc src/top.v src/hdmi_ecc.v test/lint_stubs.v --top-module top
+
+echo "Verilog linting passed successfully!"

--- a/src/hdmi_packet_packer.v
+++ b/src/hdmi_packet_packer.v
@@ -68,9 +68,14 @@ module hdmi_packet_packer (
     // Mapping to channels as per HDMI 1.3a Table 5-11
     // Channel 0: [0, VSync, HSync, Header bit]
     assign chan0_out = {1'b0, vsync, hsync, header[pixel_index]};
+
     // Channel 1: [Subpacket 1 bit i+32, Subpacket 0 bit i+32, Subpacket 1 bit i, Subpacket 0 bit i]
-    assign chan1_out = {sub1[pixel_index+32], sub0[pixel_index+32], sub1[pixel_index], sub0[pixel_index]};
+    // Use 6-bit index for subpackets to avoid linting warnings
+    wire [5:0] idx_low = {1'b0, pixel_index};
+    wire [5:0] idx_high = {1'b0, pixel_index} + 6'd32;
+
+    assign chan1_out = {sub1[idx_high], sub0[idx_high], sub1[idx_low], sub0[idx_low]};
     // Channel 2: [Subpacket 3 bit i+32, Subpacket 2 bit i+32, Subpacket 3 bit i, Subpacket 2 bit i]
-    assign chan2_out = {sub3[pixel_index+32], sub2[pixel_index+32], sub3[pixel_index], sub2[pixel_index]};
+    assign chan2_out = {sub3[idx_high], sub2[idx_high], sub3[idx_low], sub2[idx_low]};
 
 endmodule

--- a/src/tmds_encoder.v
+++ b/src/tmds_encoder.v
@@ -17,10 +17,13 @@ module tmds_encoder (
 );
 
     // --- Stage 1: Minimize transitions ---
-    wire [3:0] n1d = data[0] + data[1] + data[2] + data[3] + data[4] + data[5] + data[6] + data[7];
-    wire use_xnor = (n1d > 4) || (n1d == 4 && data[0] == 1'b0);
+    wire [3:0] n1d = {3'b0, data[0]} + {3'b0, data[1]} + {3'b0, data[2]} + {3'b0, data[3]} +
+                     {3'b0, data[4]} + {3'b0, data[5]} + {3'b0, data[6]} + {3'b0, data[7]};
+    wire use_xnor = (n1d > 4'd4) || (n1d == 4'd4 && data[0] == 1'b0);
 
+    /* verilator lint_off UNOPTFLAT */
     wire [8:0] q_m;
+    /* verilator lint_on UNOPTFLAT */
     assign q_m[0] = data[0];
     assign q_m[1] = use_xnor ? (q_m[0] ~^ data[1]) : (q_m[0] ^ data[1]);
     assign q_m[2] = use_xnor ? (q_m[1] ~^ data[2]) : (q_m[1] ^ data[2]);
@@ -33,17 +36,18 @@ module tmds_encoder (
 
     // --- Stage 2: DC Balance ---
     reg signed [4:0] cnt; // Running disparity
-    wire [3:0] n1qm = q_m[0] + q_m[1] + q_m[2] + q_m[3] + q_m[4] + q_m[5] + q_m[6] + q_m[7];
+    wire [3:0] n1qm = {3'b0, q_m[0]} + {3'b0, q_m[1]} + {3'b0, q_m[2]} + {3'b0, q_m[3]} +
+                      {3'b0, q_m[4]} + {3'b0, q_m[5]} + {3'b0, q_m[6]} + {3'b0, q_m[7]};
     wire [3:0] n0qm = 4'h8 - n1qm;
     wire signed [4:0] diff_qm = $signed({1'b0, n1qm}) - $signed({1'b0, n0qm});
 
     always @(posedge clk) begin
         if (reset) begin
             tmds <= 10'b0;
-            cnt  <= 5'b0;
+            cnt  <= 5'sh0;
         end else begin
             if (!vde) begin
-                cnt <= 5'b0;
+                cnt <= 5'sh0;
                 case (ctrl)
                     2'b00:   tmds <= 10'b1101010100;
                     2'b01:   tmds <= 10'b0010101011;
@@ -51,8 +55,8 @@ module tmds_encoder (
                     default: tmds <= 10'b1010101100;
                 endcase
             end else begin
-                if (cnt == 0 || n1qm == 4) begin
-                    if (q_m[8] == 0) begin
+                if (cnt == 5'sh0 || n1qm == 4'd4) begin
+                    if (q_m[8] == 1'b0) begin
                         tmds <= {2'b10, ~q_m[7:0]};
                         cnt  <= cnt - diff_qm;
                     end else begin
@@ -60,12 +64,12 @@ module tmds_encoder (
                         cnt  <= cnt + diff_qm;
                     end
                 end else begin
-                    if ((cnt > 0 && n1qm > 4) || (cnt < 0 && n1qm < 4)) begin
+                    if ((cnt > 5'sh0 && n1qm > 4'd4) || (cnt < 5'sh0 && n1qm < 4'd4)) begin
                         tmds <= {1'b1, q_m[8], ~q_m[7:0]};
-                        cnt  <= cnt + $signed({1'b0, q_m[8], 1'b0}) - diff_qm;
+                        cnt  <= cnt + $signed({3'b0, q_m[8], 1'b0}) - diff_qm;
                     end else begin
                         tmds <= {1'b0, q_m[8], q_m[7:0]};
-                        cnt  <= cnt - $signed({1'b0, ~q_m[8], 1'b0}) + diff_qm;
+                        cnt  <= cnt - $signed({3'b0, ~q_m[8], 1'b0}) + diff_qm;
                     end
                 end
             end

--- a/test/lint_stubs.v
+++ b/test/lint_stubs.v
@@ -1,0 +1,68 @@
+/* Linting stubs for Gowin primitives and other external modules */
+
+module rPLL #(
+    parameter FCLKIN = "27",
+    parameter DEVICE = "GW1NSR-4C",
+    parameter IDIV_SEL = 0,
+    parameter FBDIV_SEL = 0,
+    parameter ODIV_SEL = 0,
+    parameter PSDA_SEL = "0000",
+    parameter DUTYDA_SEL = "1000",
+    parameter CLKOUTD_SRC = "CLKOUT",
+    parameter DYN_SDIV_SEL = 2
+) (
+    input  wire CLKIN,
+    output wire CLKOUT,
+    output wire CLKOUTD,
+    output wire LOCK,
+    input  wire RESET,
+    input  wire RESET_P,
+    input  wire CLKFB,
+    input  wire [5:0] FBDSEL,
+    input  wire [5:0] IDSEL,
+    input  wire [5:0] ODSEL,
+    input  wire [3:0] DUTYDA,
+    input  wire [3:0] FDLY
+);
+    // Stub implementation
+    assign CLKOUT = CLKIN;
+    assign CLKOUTD = CLKIN;
+    assign LOCK = 1'b1;
+endmodule
+
+module OSER10 (
+    output wire Q,
+    input  wire D0, D1, D2, D3, D4, D5, D6, D7, D8, D9,
+    input  wire PCLK,
+    input  wire FCLK,
+    input  wire RESET
+);
+    // Stub implementation
+    assign Q = D0;
+endmodule
+
+module tt_um_vga_example (
+    input  wire [7:0] ui_in,
+    output wire [7:0] uo_out,
+    input  wire [7:0] uio_in,
+    output wire [7:0] uio_out,
+    output wire [7:0] uio_oe,
+    input  wire       ena,
+    input  wire       clk,
+    input  wire       rst_n
+);
+    // Stub implementation
+    assign uo_out = 8'b0;
+    assign uio_out = 8'b0;
+    assign uio_oe = 8'b0;
+endmodule
+
+module Gowin_EMPU_Top (
+    input sys_clk,
+    inout [15:0] gpio,
+    input uart0_rxd,
+    output uart0_txd,
+    input reset_n
+);
+    assign uart0_txd = 1'b1;
+endmodule


### PR DESCRIPTION
This change adds Verilog linting to the project's CI/CD pipeline using Verilator. 

Key changes include:
- **Toolchain Update**: `install.sh` now installs `verilator`.
- **Linting Script**: Added `scripts/lint.sh` to provide a consistent way to run linting locally and in CI.
- **Linting Stubs**: Created `test/lint_stubs.v` to define stubs for Gowin-specific primitives (rPLL, OSER10) and other external modules, allowing Verilator to perform a full-design lint.
- **Code Refinement**: Resolved several `WIDTHEXPAND` and `SIGNED` warnings in the TMDS encoder and packet packer modules to ensure a clean lint report and follow hardware design best practices.
- **CI Integration**: Added a "Lint Verilog" step to `.github/workflows/test.yml` that runs before the simulation tests.

Fixes #92

---
*PR created automatically by Jules for task [9995894095640409119](https://jules.google.com/task/9995894095640409119) started by @chatelao*