### PR TITLE
Add WITHOUT_M3 compilation option and CI integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,7 @@ jobs:
 
       - name: Compile All TT VGA Projects
         run: bash examples/compile_all_projects.sh
+
+      - name: Verify Top Synthesis WITHOUT_M3
+        run: |
+          yosys -p "read_verilog -DWITHOUT_M3 src/top.v src/hdmi_clk_gen.v src/hdmi_tx.v src/tmds_encoder.v src/hdmi_serializer.v src/hdmi_data_island_framer.v src/hdmi_data_island_fsm.v src/hdmi_packet_packer.v src/hdmi_ecc.v src/terc4_encoder.v src/hdmi_data_island_scheduler.v src/hdmi_avi_infoframe.v src/hdmi_acr_packet.v src/hdmi_infoframe_checksum.v src/hvsync_generator.v test/lint_stubs.v; synth_gowin -top top"

--- a/scripts/build_examples.sh
+++ b/scripts/build_examples.sh
@@ -11,6 +11,9 @@ DEVICE="GW1NSR-LV4CQN48PC7/I6"
 FAMILY="GW1NS-4"
 CST="src/top.cst"
 
+# Options
+WITHOUT_M3=${WITHOUT_M3:-1}
+
 # HDMI Source files (excluding M3 for better compatibility with open toolchain)
 HDMI_SOURCES="src/top.v src/hdmi_clk_gen.v src/hdmi_tx.v src/tmds_encoder.v src/hdmi_serializer.v \
 src/hdmi_data_island_framer.v src/hdmi_data_island_fsm.v src/hdmi_packet_packer.v \
@@ -36,8 +39,13 @@ build_example() {
 
     # Synthesis
     local yosys_cmd=""
+    local read_verilog_flags=""
+    if [ "$WITHOUT_M3" -eq 1 ]; then
+        read_verilog_flags="-DWITHOUT_M3"
+    fi
+
     for src in $all_sources; do
-        yosys_cmd+="read_verilog $src; "
+        yosys_cmd+="read_verilog $read_verilog_flags $src; "
     done
     if [ "$top_mod" != "tt_um_vga_example" ]; then
         yosys_cmd+="rename $top_mod tt_um_vga_example; "

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -14,6 +14,10 @@ echo "Running Verilog linting..."
 # - --top-module top: Specify the top-level module
 # - -Wall: Enable all warnings (optional, adjust as needed)
 
+echo "--- Linting WITH M3 (default) ---"
 verilator --lint-only -Isrc src/top.v src/hdmi_ecc.v test/lint_stubs.v --top-module top
+
+echo "--- Linting WITHOUT M3 ---"
+verilator --lint-only -Isrc -DWITHOUT_M3 src/top.v src/hdmi_ecc.v test/lint_stubs.v --top-module top
 
 echo "Verilog linting passed successfully!"

--- a/src/top.v
+++ b/src/top.v
@@ -14,6 +14,7 @@ module top (
     output wire [2:0] tmds_d_p
 );
 
+`ifndef WITHOUT_M3
     wire [15:0] m3_gpio;
 
     // --- M3 System ---
@@ -24,6 +25,9 @@ module top (
         .uart0_txd(uart0_txd),
         .reset_n(btn2_pin)
     );
+`else
+    assign uart0_txd = 1'b1;
+`endif
 
     // --- Clock Generation ---
     wire clk_pixel;

--- a/test/lint_stubs.v
+++ b/test/lint_stubs.v
@@ -1,5 +1,6 @@
 /* Linting stubs for Gowin primitives and other external modules */
 
+`ifdef VERILATOR
 module rPLL #(
     parameter FCLKIN = "27",
     parameter DEVICE = "GW1NSR-4C",
@@ -40,6 +41,7 @@ module OSER10 (
     // Stub implementation
     assign Q = D0;
 endmodule
+`endif
 
 module tt_um_vga_example (
     input  wire [7:0] ui_in,


### PR DESCRIPTION
This change introduces a `WITHOUT_M3` Verilog macro that allows the project to be compiled without the Cortex-M3 system. This is particularly useful for open-source toolchain compatibility on the Tang Nano 4K, as `nextpnr-gowin` and `yosys` have limited support for the proprietary EMPU core.

Key changes:
1.  **Verilog Logic**: `src/top.v` now wraps the M3 instantiation in `` `ifndef WITHOUT_M3 `` blocks. If `WITHOUT_M3` is defined, `uart0_txd` is driven to a default high state.
2.  **Linting**: `scripts/lint.sh` now lints the top module twice to ensure both code paths remain valid.
3.  **Build Scripts**: `scripts/build_examples.sh` now respects the `WITHOUT_M3` environment variable (defaulting to 1 for better open-toolchain success) and uses the correct Yosys `read_verilog -D` syntax.
4.  **CI/CD**: The GitHub Actions workflow now includes an explicit Yosys synthesis step with `-DWITHOUT_M3` to prevent regressions in the open-source build path.

Fixes #96

---
*PR created automatically by Jules for task [3153208166921849186](https://jules.google.com/task/3153208166921849186) started by @chatelao*